### PR TITLE
Isolate dependencies from other add-ons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ CMakeCache.txt
 Makefile
 lib
 
-#Selenium
+# Selenium
 __hubs_selenium_profile
+
+# Dependencies
+addons/io_hubs_addon/.__deps__

--- a/addons/io_hubs_addon/__init__.py
+++ b/addons/io_hubs_addon/__init__.py
@@ -1,5 +1,4 @@
 from .utils import create_prefs_dir
-from .utils import get_user_python_path
 import sys
 import bpy
 from .io import gltf_exporter, gltf_importer, panels
@@ -22,7 +21,6 @@ bl_info = {
     "category": "Generic"
 }
 
-sys.path.insert(0, get_user_python_path())
 
 create_prefs_dir()
 

--- a/addons/io_hubs_addon/debugger.py
+++ b/addons/io_hubs_addon/debugger.py
@@ -3,7 +3,7 @@ import bpy
 from bpy.types import Context
 
 from .preferences import EXPORT_TMP_FILE_NAME, EXPORT_TMP_SCREENSHOT_FILE_NAME
-from .utils import isModuleAvailable, save_prefs, find_area, image_type_to_file_ext
+from .utils import is_module_available, save_prefs, find_area, image_type_to_file_ext
 from .icons import get_hubs_icons
 from .hubs_session import HubsSession, PARAMS_TO_STRING
 from . import api
@@ -238,7 +238,7 @@ class HUBS_PT_ToolsSceneDebuggerCreatePanel(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context: Context):
-        return isModuleAvailable("selenium")
+        return is_module_available("selenium")
 
     def draw(self, context: Context):
         prefs = context.window_manager.hubs_scene_debugger_prefs
@@ -270,7 +270,7 @@ class HUBS_PT_ToolsSceneDebuggerOpenPanel(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context: Context):
-        return isModuleAvailable("selenium")
+        return is_module_available("selenium")
 
     def draw(self, context: Context):
         box = self.layout.box()
@@ -303,7 +303,7 @@ class HUBS_PT_ToolsSceneDebuggerUpdatePanel(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context: Context):
-        return isModuleAvailable("selenium")
+        return is_module_available("selenium")
 
     def draw(self, context: Context):
         box = self.layout.box()
@@ -379,7 +379,7 @@ class HUBS_PT_ToolsSceneSessionPanel(bpy.types.Panel):
     def draw(self, context):
         main_box = self.layout.box()
 
-        if isModuleAvailable("selenium"):
+        if is_module_available("selenium"):
             row = main_box.row(align=True)
             row.alignment = "CENTER"
             col = row.column()
@@ -454,7 +454,7 @@ class HUBS_PT_ToolsSceneDebuggerPanel(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context: Context):
-        return isModuleAvailable("selenium")
+        return is_module_available("selenium")
 
     def draw(self, context):
         params_icons = {}
@@ -860,7 +860,7 @@ class HUBS_PT_ToolsSceneDebuggerPublishScenePanel(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context: Context):
-        return isModuleAvailable("selenium")
+        return is_module_available("selenium")
 
     def draw(self, context: Context):
         if not hubs_session.is_alive() or not hubs_session.user_logged_in:

--- a/addons/io_hubs_addon/dependencies/__init__.py
+++ b/addons/io_hubs_addon/dependencies/__init__.py
@@ -5,7 +5,7 @@ selenium = None
 
 def get_selenium():
     global selenium
-    if selenium == None:
+    if selenium is None:
         selenium = load_dependency("selenium.webdriver")
 
     return selenium

--- a/addons/io_hubs_addon/dependencies/__init__.py
+++ b/addons/io_hubs_addon/dependencies/__init__.py
@@ -1,0 +1,11 @@
+from ..utils import load_dependency
+
+selenium = None
+
+
+def get_selenium():
+    global selenium
+    if selenium == None:
+        selenium = load_dependency("selenium.webdriver")
+
+    return selenium

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -51,7 +51,7 @@ class InstallDepsOperator(bpy.types.Operator):
             dep = f'{self.dep_config.name}=={self.dep_config.version}'
 
         result = subprocess.run(
-            [sys.executable, '-m', 'pip', 'install', dep,
+            [sys.executable, '-m', 'pip', 'install', '--upgrade', dep,
              '-t', get_or_create_deps_path(self.dep_config.name)],
             capture_output=True, text=True, input="y")
         failed = False

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -1,6 +1,6 @@
 import bpy
 from bpy.types import AddonPreferences, Context
-from bpy.props import IntProperty, StringProperty, EnumProperty, BoolProperty, CollectionProperty, PointerProperty
+from bpy.props import IntProperty, StringProperty, EnumProperty, BoolProperty, PointerProperty
 from .utils import get_addon_package, is_module_available, get_browser_profile_directory
 import platform
 from os.path import join, dirname, realpath
@@ -72,11 +72,9 @@ class InstallDepsOperator(bpy.types.Operator):
 class UninstallDepsOperator(bpy.types.Operator):
     bl_idname = "pref.hubs_prefs_uninstall_dep"
     bl_label = "Uninstall a python dependency through pip"
-    bl_property = "dep_names"
     bl_options = {'REGISTER', 'UNDO'}
 
     dep_config: PointerProperty(type=DepsProperty)
-    force: BoolProperty(default=False)
 
     def execute(self, context):
         from .utils import get_or_create_deps_path
@@ -137,10 +135,6 @@ class HubsPreferences(AddonPreferences):
         items=[("Firefox", "Firefox", "Use Firefox as the viewer browser"),
                ("Chrome", "Chrome", "Use Chrome as the viewer browser")],
         default="Firefox")
-
-    force_uninstall: BoolProperty(
-        default=False, name="Force",
-        description="Force uninstall of the selenium dependencies by deleting the module directory")
 
     override_firefox_path: BoolProperty(
         name="Override Firefox executable path", description="Override Firefox executable path", default=False)
@@ -213,7 +207,6 @@ class HubsPreferences(AddonPreferences):
             "Selenium module not found. These modules are required to run the viewer")
         row = modules_box.row()
         if modules_available:
-            row.prop(self, "force_uninstall")
             op = row.operator(UninstallDepsOperator.bl_idname,
                               text="Uninstall dependencies (selenium)")
             op.dep_config.name = "selenium"

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.types import AddonPreferences, Context
-from bpy.props import IntProperty, StringProperty, EnumProperty, BoolProperty, CollectionProperty
-from .utils import get_addon_package, isModuleAvailable, get_browser_profile_directory
+from bpy.props import IntProperty, StringProperty, EnumProperty, BoolProperty, CollectionProperty, PointerProperty
+from .utils import get_addon_package, is_module_available, get_browser_profile_directory
 import platform
 from os.path import join, dirname, realpath
 
@@ -39,37 +39,24 @@ class InstallDepsOperator(bpy.types.Operator):
     bl_property = "dep_names"
     bl_options = {'REGISTER', 'UNDO'}
 
-    dep_names: CollectionProperty(type=DepsProperty)
+    dep_config: PointerProperty(type=DepsProperty)
 
     def execute(self, context):
         import subprocess
         import sys
 
-        result = subprocess.run([sys.executable, '-m', 'ensurepip'],
-                                capture_output=False, text=True, input="y")
-        if result.returncode < 0:
-            print(result.stderr)
-            bpy.ops.wm.hubs_report_viewer('INVOKE_DEFAULT', title="Hubs scene debugger report",
-                                          report_string='\n\n'.join(["Dependencies install has failed",
-                                                                     f'{result.stderr}']))
-            return {'CANCELLED'}
+        from .utils import get_or_create_deps_path
+        dep = self.dep_config.name
+        if self.dep_config.version:
+            dep = f'{self.dep_config.name}=={self.dep_config.version}'
 
-        deps = []
-        for _, dep in self.dep_names.items():
-            if dep.version:
-                deps.append(f'{dep.name}=={dep.version}')
-            else:
-                deps.append(dep.name)
-
-        from .utils import get_user_python_path
         result = subprocess.run(
-            [sys.executable, '-m', 'pip', 'install', *deps,
-             '-t', get_user_python_path()],
+            [sys.executable, '-m', 'pip', 'install', dep,
+             '-t', get_or_create_deps_path(self.dep_config.name)],
             capture_output=True, text=True, input="y")
         failed = False
-        for _, dep in self.dep_names.items():
-            if not isModuleAvailable(dep.name):
-                failed = True
+        if not is_module_available(self.dep_config.name):
+            failed = True
         if result.returncode != 0 or failed:
             print(result.stderr)
             bpy.ops.wm.hubs_report_viewer('INVOKE_DEFAULT', title="Hubs scene debugger report",
@@ -88,52 +75,14 @@ class UninstallDepsOperator(bpy.types.Operator):
     bl_property = "dep_names"
     bl_options = {'REGISTER', 'UNDO'}
 
-    dep_names: CollectionProperty(type=DepsProperty)
+    dep_config: PointerProperty(type=DepsProperty)
     force: BoolProperty(default=False)
 
     def execute(self, context):
-        import subprocess
-        import sys
+        from .utils import get_or_create_deps_path
+        import shutil
+        shutil.rmtree(get_or_create_deps_path(self.dep_config.name))
 
-        result = subprocess.run([sys.executable, '-m', 'ensurepip'],
-                                capture_output=False, text=True, input="y")
-        if result.returncode < 0:
-            print(result.stderr)
-            bpy.ops.wm.hubs_report_viewer('INVOKE_DEFAULT', title="Hubs scene debugger report",
-                                          report_string='\n\n'.join(["Dependencies uninstall has failed",
-                                                                     f'{result.stderr}']))
-            return {'CANCELLED'}
-
-        for name, _ in self.dep_names.items():
-            del name
-
-        result = subprocess.run(
-            [sys.executable, '-m', 'pip', 'uninstall', *
-                [name for name, _ in self.dep_names.items()]],
-            capture_output=True, text=True, input="y")
-
-        failed = False
-        for name, _ in self.dep_names.items():
-            if isModuleAvailable(name):
-                failed = True
-        if result.returncode != 0 or failed:
-            print(result.stderr)
-            bpy.ops.wm.hubs_report_viewer('INVOKE_DEFAULT', title="Hubs scene debugger report",
-                                          report_string='\n\n'.join(["Dependencies install has failed",
-                                                                     f'{result.stderr}']))
-            return {'CANCELLED'}
-
-        if self.force:
-            import os
-            from .utils import get_user_python_path
-            deps_paths = [os.path.join(get_user_python_path(), name)
-                          for name, _ in self.dep_names.items()]
-            import shutil
-            for dep_path in deps_paths:
-                shutil.rmtree(dep_path)
-
-        bpy.ops.wm.hubs_report_viewer('INVOKE_DEFAULT', title="Hubs scene debugger report",
-                                      report_string="Dependencies uninstalled successfully")
         return {'FINISHED'}
 
 
@@ -209,7 +158,7 @@ class HubsPreferences(AddonPreferences):
         box.row().prop(self, "row_length")
         box.row().prop(self, "recast_lib_path")
 
-        selenium_available = isModuleAvailable("selenium")
+        selenium_available = is_module_available("selenium")
         modules_available = selenium_available
         box = layout.box()
         box.label(text="Scene debugger configuration")
@@ -267,13 +216,12 @@ class HubsPreferences(AddonPreferences):
             row.prop(self, "force_uninstall")
             op = row.operator(UninstallDepsOperator.bl_idname,
                               text="Uninstall dependencies (selenium)")
-            op.dep_names.add().name = "selenium"
+            op.dep_config.name = "selenium"
         else:
             op = row.operator(InstallDepsOperator.bl_idname,
                               text="Install dependencies (selenium)")
-            dep = op.dep_names.add()
-            dep.name = "selenium"
-            dep.version = "4.15.2"
+            op.dep_config.name = "selenium"
+            op.dep_config.version = "4.15.2"
 
 
 def register():


### PR DESCRIPTION
This PR isolates selenium from the Blender python packages to avoid conflicts. We still do it using pip but using a specific target directory and now the modules are loaded in isolation using importlib.