### PR TITLE
Support for user components directories

### DIFF
--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -38,28 +38,36 @@ def get_user_component_names():
     component_names = []
     from ..preferences import get_addon_pref
     addon_prefs = get_addon_pref(bpy.context)
-    for _, entry in enumerate(addon_prefs.user_components_paths):
+    for entry in addon_prefs.user_components_paths:
         if entry.path and os.path.isdir(entry.path):
-            component_names = get_components_in_dir(entry.path)
+            component_names.append(get_components_in_dir(entry.path))
     return component_names
+
+
+def get_user_component_paths():
+    component_paths = []
+    from ..preferences import get_addon_pref
+    addon_prefs = get_addon_pref(bpy.context)
+    for entry in addon_prefs.user_components_paths:
+        if entry.path and os.path.isdir(entry.path):
+            components = get_components_in_dir(entry.path)
+            for component in components:
+                component_paths.append(os.path.join(entry.path, component + ".py"))
+    return component_paths
 
 
 def get_user_component_definitions():
     modules = []
-    component_names = get_user_component_names()
-    for name in component_names:
-        from ..preferences import get_addon_pref
-        addon_prefs = get_addon_pref(bpy.context)
-        for _, entry in enumerate(addon_prefs.user_components_paths):
-            file_path = os.path.join(entry.path, name + ".py")
-            try:
-                spec = importlib.util.spec_from_file_location(name, file_path)
-                mod = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(mod)
-                modules.append(mod)
+    component_paths = get_user_component_paths()
+    for component_path in component_paths:
+        try:
+            spec = importlib.util.spec_from_file_location(component_path, component_path)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            modules.append(mod)
 
-            except Exception as e:
-                print(f'Failed import of component {name}', e)
+        except Exception as e:
+            print(f'Failed import of component {component_path}', e)
     return modules
 
 

--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -39,7 +39,7 @@ def get_user_component_names():
     from ..preferences import get_addon_pref
     addon_prefs = get_addon_pref(bpy.context)
     for _, entry in enumerate(addon_prefs.user_components_paths):
-        if entry.path:
+        if entry.path and os.path.isdir(entry.path):
             component_names = get_components_in_dir(entry.path)
     return component_names
 
@@ -147,10 +147,14 @@ def load_user_components():
     for module in get_user_component_definitions():
         for _, member in inspect.getmembers(module):
             if inspect.isclass(member) and issubclass(member, HubsComponent) and module.__name__ == member.__module__:
-                if hasattr(module, 'register_module'):
-                    module.register_module()
-                register_component(member)
-                __components_registry[member.get_name()] = member
+                try:
+                    if hasattr(module, 'register_module'):
+                        module.register_module()
+                    register_component(member)
+                    __components_registry[member.get_name()] = member
+                except Exception:
+                    import traceback
+                    traceback.print_exc()
 
 
 def unload_user_components():

--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -180,8 +180,9 @@ def load_components_registry():
                 register_component(member)
                 __components_registry[member.get_name()] = member
 
-    # Preferences are not accessible until the add-on is enabled so we need to check that before loading the user
-    # components as they depend on the preferences.
+    # When running Blender in factory startup mode and specifying an addon, that addon's register function is called.
+    # As preferences are not available until the addon is enabled, the user component load fails when accessing them.
+    # This happens when running tests and this guard avoids crashing in that scenario.
     from ..utils import is_addon_enabled
     if is_addon_enabled():
         load_user_components()

--- a/addons/io_hubs_addon/components/components_registry.py
+++ b/addons/io_hubs_addon/components/components_registry.py
@@ -176,7 +176,11 @@ def load_components_registry():
                 register_component(member)
                 __components_registry[member.get_name()] = member
 
-    load_user_components()
+    # Preferences are not accessible until the add-on is enabled so we need to check that before loading the user
+    # components as they depend on the preferences.
+    from ..utils import is_addon_enabled
+    if is_addon_enabled():
+        load_user_components()
 
 
 def unload_components_registry():

--- a/addons/io_hubs_addon/components/types.py
+++ b/addons/io_hubs_addon/components/types.py
@@ -23,6 +23,7 @@ class Category(Enum):
     MISC = 'Misc'
     LIGHTS = 'Lights'
     MEDIA = 'Media'
+    USER = 'User'
 
 
 class MigrationType(Enum):

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -130,6 +130,101 @@ class DeleteProfileOperator(bpy.types.Operator):
         return {'FINISHED'}
 
 
+def reload_user_components():
+    from .components.components_registry import unload_user_components, load_user_components
+    unload_user_components()
+    load_user_components()
+
+
+class HubsUserComponentsPath(bpy.types.PropertyGroup):
+    name: StringProperty(
+        name='User components path entry name',
+        description='The user components path entry name.',
+    )
+    path: StringProperty(
+        name='User components path path',
+        description='The user components path path. You can copy external components here.',
+        subtype='FILE_PATH'
+    )
+
+
+class HubsUserComponentsPathAdd(bpy.types.Operator):
+    bl_idname = "hubs_preferences.add_user_components_path"
+    bl_label = "Add user components path"
+    bl_description = "Adds a new component path entry"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    path: bpy.props.StringProperty(name="User Components Path", default="")
+
+    def execute(self, context):
+        addon_prefs = addon_prefs = get_addon_pref(bpy.context)
+        paths = addon_prefs.user_components_paths
+        new_path = paths.add()
+        new_path.path = self.path
+
+        return {'FINISHED'}
+
+
+class HubsUserComponentsPathRemove(bpy.types.Operator):
+    bl_idname = "hubs_preferences.remove_user_components_path"
+    bl_label = "Remove user components path entry"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    index: bpy.props.IntProperty(name="User Components Path Index", default=0)
+
+    def execute(self, context):
+        addon_prefs = addon_prefs = get_addon_pref(bpy.context)
+        paths = addon_prefs.user_components_paths
+        paths.remove(self.index)
+
+        return {'FINISHED'}
+
+
+def draw_user_modules_path_panel(context, layout, prefs):
+    box = layout.box()
+    box.row().label(text="Additional components directories:")
+
+    dirs_layout = box.row()
+
+    entries = prefs.user_components_paths
+
+    if len(entries) == 0:
+        dirs_layout.operator(HubsUserComponentsPathAdd.bl_idname,
+                             text="Add", icon='ADD')
+        return
+
+    dirs_layout.use_property_split = False
+    dirs_layout.use_property_decorate = False
+
+    box = dirs_layout.box()
+    split = box.split(factor=0.35)
+    name_col = split.column()
+    path_col = split.column()
+
+    row = name_col.row(align=True)  # Padding
+    row.separator()
+    row.label(text="Name")
+
+    row = path_col.row(align=True)  # Padding
+    row.separator()
+    row.label(text="Path")
+
+    row.operator(HubsUserComponentsPathAdd.bl_idname,
+                 text="", icon='ADD', emboss=False)
+
+    for i, entry in enumerate(entries):
+        row = name_col.row()
+        row.alert = not entry.name
+        row.prop(entry, "name", text="")
+
+        row = path_col.row()
+        subrow = row.row()
+        subrow.alert = not entry.path
+        subrow.prop(entry, "path", text="")
+        row.operator(HubsUserComponentsPathRemove.bl_idname,
+                     text="", icon='X', emboss=False).index = i
+
+
 class HubsPreferences(AddonPreferences):
     bl_idname = __package__
 
@@ -163,6 +258,8 @@ class HubsPreferences(AddonPreferences):
     chrome_path: StringProperty(
         name="Chrome executable path", description="Binary path", subtype='FILE_PATH')
 
+    user_components_paths: CollectionProperty(type=HubsUserComponentsPath)
+
     def draw(self, context):
         layout = self.layout
         box = layout.box()
@@ -170,11 +267,11 @@ class HubsPreferences(AddonPreferences):
         box.row().prop(self, "row_length")
         box.row().prop(self, "recast_lib_path")
 
-        selenium_available = is_module_available("selenium")
-        modules_available = selenium_available
+        draw_user_modules_path_panel(context, layout, self)
         box = layout.box()
         box.label(text="Scene debugger configuration")
 
+        modules_available = is_module_available("selenium")
         if modules_available:
             browser_box = box.box()
             row = browser_box.row()
@@ -236,6 +333,9 @@ class HubsPreferences(AddonPreferences):
 
 
 def register():
+    bpy.utils.register_class(HubsUserComponentsPath)
+    bpy.utils.register_class(HubsUserComponentsPathAdd)
+    bpy.utils.register_class(HubsUserComponentsPathRemove)
     bpy.utils.register_class(DepsProperty)
     bpy.utils.register_class(HubsPreferences)
     bpy.utils.register_class(InstallDepsOperator)
@@ -249,3 +349,6 @@ def unregister():
     bpy.utils.unregister_class(InstallDepsOperator)
     bpy.utils.unregister_class(HubsPreferences)
     bpy.utils.unregister_class(DepsProperty)
+    bpy.utils.unregister_class(HubsUserComponentsPathRemove)
+    bpy.utils.unregister_class(HubsUserComponentsPathAdd)
+    bpy.utils.unregister_class(HubsUserComponentsPath)

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -130,20 +130,14 @@ class DeleteProfileOperator(bpy.types.Operator):
         return {'FINISHED'}
 
 
-def reload_user_components():
-    from .components.components_registry import unload_user_components, load_user_components
-    unload_user_components()
-    load_user_components()
-
-
 class HubsUserComponentsPath(bpy.types.PropertyGroup):
     name: StringProperty(
         name='User components path entry name',
-        description='The user components path entry name.',
+        description='An optional, user defined label to allow quick discernment between different user component definition directories.',
     )
     path: StringProperty(
         name='User components path path',
-        description='The user components path path. You can copy external components here.',
+        description='The path to a user defined component definitions directory. You can copy external components here and they will be loaded automatically.',
         subtype='FILE_PATH'
     )
 
@@ -154,13 +148,10 @@ class HubsUserComponentsPathAdd(bpy.types.Operator):
     bl_description = "Adds a new component path entry"
     bl_options = {'REGISTER', 'UNDO'}
 
-    path: bpy.props.StringProperty(name="User Components Path", default="")
-
     def execute(self, context):
         addon_prefs = addon_prefs = get_addon_pref(bpy.context)
         paths = addon_prefs.user_components_paths
-        new_path = paths.add()
-        new_path.path = self.path
+        paths.add()
 
         return {'FINISHED'}
 

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -1,6 +1,6 @@
 import bpy
 from bpy.types import AddonPreferences, Context
-from bpy.props import IntProperty, StringProperty, EnumProperty, BoolProperty, PointerProperty
+from bpy.props import IntProperty, StringProperty, EnumProperty, BoolProperty, PointerProperty, CollectionProperty
 from .utils import get_addon_package, is_module_available, get_browser_profile_directory
 import platform
 from os.path import join, dirname, realpath

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -153,6 +153,8 @@ class HubsUserComponentsPathAdd(bpy.types.Operator):
         paths = addon_prefs.user_components_paths
         paths.add()
 
+        context.preferences.is_dirty = True
+
         return {'FINISHED'}
 
 
@@ -167,6 +169,8 @@ class HubsUserComponentsPathRemove(bpy.types.Operator):
         addon_prefs = addon_prefs = get_addon_pref(bpy.context)
         paths = addon_prefs.user_components_paths
         paths.remove(self.index)
+
+        context.preferences.is_dirty = True
 
         return {'FINISHED'}
 

--- a/addons/io_hubs_addon/preferences.py
+++ b/addons/io_hubs_addon/preferences.py
@@ -130,15 +130,20 @@ class DeleteProfileOperator(bpy.types.Operator):
         return {'FINISHED'}
 
 
+def set_prefs_dirty(self, context):
+    context.preferences.is_dirty = True
+
+
 class HubsUserComponentsPath(bpy.types.PropertyGroup):
     name: StringProperty(
         name='User components path entry name',
         description='An optional, user defined label to allow quick discernment between different user component definition directories.',
-    )
+        update=set_prefs_dirty)
     path: StringProperty(
         name='User components path path',
         description='The path to a user defined component definitions directory. You can copy external components here and they will be loaded automatically.',
-        subtype='FILE_PATH'
+        subtype='FILE_PATH',
+        update=set_prefs_dirty
     )
 
 

--- a/addons/io_hubs_addon/utils.py
+++ b/addons/io_hubs_addon/utils.py
@@ -286,3 +286,8 @@ def image_type_to_file_ext(image_type):
     elif image_type == 'TARGA_RAW':
         file_extension = '.tga'
     return file_extension
+
+
+def is_addon_enabled():
+    import bpy
+    return get_addon_package() in bpy.context.preferences.addons


### PR DESCRIPTION
This PR adds support for custom user components directories.

The user can add multiple directories and the components found in those directories will be loaded at add-on load time. 

We don't do hot reloading as it can get quite complex quickly and Blender already requires reload for it's own scripts paths AFAIK.

Required by https://github.com/MozillaReality/hubs-postprocessing-addon
Closes https://github.com/MozillaReality/hubs-blender-exporter/issues/288