### PR TITLE
Restore query docs

### DIFF
--- a/addons/io_hubs_addon/debugger.py
+++ b/addons/io_hubs_addon/debugger.py
@@ -9,6 +9,7 @@ from .hubs_session import HubsSession, PARAMS_TO_STRING
 from . import api
 from bpy.types import AnyType
 
+DEMO_SERVER_URL = ""
 ROOM_FLAGS_DOC_URL = "https://github.com/Hubs-Foundation/hubs-docs/blob/master/docs/hubs-query-string-parameters.md"
 
 
@@ -294,7 +295,7 @@ class HUBS_PT_ToolsSceneDebuggerOpenPanel(bpy.types.Panel):
         col = row.column()
         op = col.operator(HubsSceneDebuggerRoomAdd.bl_idname,
                           icon='ADD', text="")
-        op.url = ""
+        op.url = DEMO_SERVER_URL
         col.operator(HubsSceneDebuggerRoomRemove.bl_idname,
                      icon='REMOVE', text="")
 
@@ -500,7 +501,7 @@ def add_instance(context):
     prefs = context.window_manager.hubs_scene_debugger_prefs
     new_instance = prefs.hubs_instances.add()
     new_instance.name = "Demo Hub"
-    new_instance.url = ""
+    new_instance.url = DEMO_SERVER_URL
     prefs.hubs_instance_idx = len(
         prefs.hubs_instances) - 1
 
@@ -1053,7 +1054,7 @@ def set_url(self, value):
         parsed = parsed._replace(scheme="https")
         self.url_ = urllib.parse.urlunparse(parsed)
     except Exception:
-        self.url_ = ""
+        self.url_ = DEMO_SERVER_URL
 
 
 def get_url(self):

--- a/addons/io_hubs_addon/debugger.py
+++ b/addons/io_hubs_addon/debugger.py
@@ -9,7 +9,7 @@ from .hubs_session import HubsSession, PARAMS_TO_STRING
 from . import api
 from bpy.types import AnyType
 
-ROOM_FLAGS_DOC_URL = "https://update-with-hubs-query-string-parameters"
+ROOM_FLAGS_DOC_URL = "https://github.com/Hubs-Foundation/hubs-docs/blob/master/docs/hubs-query-string-parameters.md"
 
 
 def export_scene(context):


### PR DESCRIPTION
Restore query string docs pointing to the repo.
Refactor the demo server URL to make it easier to update when it's ready.