### PR TITLE
Support importing older scale audio feedback components.

### DIFF
--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -123,9 +123,10 @@ class HubsComponent(PropertyGroup):
     @classmethod
     def gather_import(cls, gltf, blender_host, component_name, component_value, import_report, blender_ob=None):
         component = import_component(component_name, blender_host)
-        for property_name, property_value in component_value.items():
-            assign_property(gltf.vnodes, component,
-                            property_name, property_value)
+        if component_value:
+            for property_name, property_value in component_value.items():
+                assign_property(gltf.vnodes, component,
+                                property_name, property_value)
 
     def post_export(self, export_settings, host, ob=None):
         '''This is called by the exporter after the export process has finished'''


### PR DESCRIPTION
Skip importing properties for components if they don't have any. Older scale audio feedback components didn't have component properties and were just the name and an empty string.