### PR TITLE
 Add support for importing reflection probes.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -752,14 +752,16 @@ class ReflectionProbe(HubsComponent):
                 "index": gather_texture(self.envMapTexture, export_settings)
             }
         }
-    
+
     @classmethod
     def gather_import(cls, gltf, blender_host, component_name, component_value, import_report, blender_ob=None):
         # Reflection Probes import as empties, so add a Light Probe object to host the component and parent it to the empty.
         probe_type = 'CUBE' if bpy.app.version < (4, 1, 0) else 'SPHERE'
-        lightprobe_data = bpy.data.lightprobes.new(blender_host.name, probe_type)
-        lightprobe_data.influence_type ='BOX'
-        lightprobe_object = bpy.data.objects.new(blender_host.name, lightprobe_data)
+        reflecion_probe_name = blender_host.name
+        blender_host.name = f"{blender_host.name}_node"
+        lightprobe_data = bpy.data.lightprobes.new(reflecion_probe_name, probe_type)
+        lightprobe_data.influence_type = 'BOX'
+        lightprobe_object = bpy.data.objects.new(reflecion_probe_name, lightprobe_data)
         lightprobe_object.location = blender_host.location
         lightprobe_object.rotation_quaternion = blender_host.rotation_quaternion
         lightprobe_object.scale = blender_host.scale

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -763,6 +763,7 @@ class ReflectionProbe(HubsComponent):
         lightprobe_data.influence_type = 'BOX'
         lightprobe_object = bpy.data.objects.new(reflecion_probe_name, lightprobe_data)
         lightprobe_object.location = blender_host.location
+        lightprobe_object.rotation_mode = 'QUATERNION'
         lightprobe_object.rotation_quaternion = blender_host.rotation_quaternion
         lightprobe_object.scale = blender_host.scale
         lightprobe_object.parent = blender_host

--- a/addons/io_hubs_addon/io/gltf_importer.py
+++ b/addons/io_hubs_addon/io/gltf_importer.py
@@ -4,7 +4,7 @@ from io_scene_gltf2.blender.imp.gltf2_blender_node import BlenderNode
 from io_scene_gltf2.blender.imp.gltf2_blender_material import BlenderMaterial
 from io_scene_gltf2.blender.imp.gltf2_blender_scene import BlenderScene
 from io_scene_gltf2.blender.imp.gltf2_blender_image import BlenderImage
-from .utils import HUBS_CONFIG, import_image, import_all_images
+from .utils import HUBS_CONFIG, import_image, import_all_textures
 from ..components.components_registry import get_component_by_name
 import traceback
 
@@ -142,7 +142,7 @@ class glTF2ImportUserExtension:
                 gltf.import_settings['gltf_yup'] = gltf.data.asset.extras[
                     'gltf_yup']
 
-        import_all_images(gltf)
+        import_all_textures(gltf)
 
     def gather_import_scene_after_nodes_hook(self, gltf_scene, blender_scene, gltf):
         if not self.properties.enabled:
@@ -253,7 +253,7 @@ def patched_BlenderScene_create(gltf):
     delayed_gathers.clear()
     import_report.clear()
 
-    import_all_images(gltf)
+    import_all_textures(gltf)
     orig_BlenderScene_create(gltf)
     gltf_scene = gltf.data.scenes[gltf.data.scene]
     blender_object = bpy.data.scenes[gltf.blender_scene]

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -26,7 +26,7 @@ HUBS_CONFIG = {
     "gltfExtensionVersion": 4,
 }
 
-imported_images = {}
+imported_textures = {}
 
 # gather_texture/image with HDR support via MOZ_texture_rgbe
 
@@ -414,16 +414,16 @@ def import_image(gltf, gltf_texture):
     return blender_image_name, source
 
 
-def import_all_images(gltf):
-    global imported_images
-    imported_images.clear()
+def import_all_textures(gltf):
+    global imported_textures
+    imported_textures.clear()
 
     if not gltf.data.textures:
         return
 
-    for gltf_texture in gltf.data.textures:
+    for index, gltf_texture in enumerate(gltf.data.textures):
         blender_image_name, source = import_image(gltf, gltf_texture)
-        imported_images[source] = blender_image_name
+        imported_textures[index] = blender_image_name
 
 
 def import_component(component_name, blender_object):
@@ -467,8 +467,8 @@ def assign_property(vnodes, blender_component, property_name, property_value):
                         setattr(blender_component, "bone",
                                 bone_vnode.blender_bone_name)
                 elif property_value['__mhc_link_type'] == "texture":
-                    global imported_images
-                    blender_image_name = imported_images[property_value['index']]
+                    global imported_textures
+                    blender_image_name = imported_textures[property_value['index']]
                     blender_image = bpy.data.images[blender_image_name]
                     setattr(blender_component, property_name, blender_image)
 


### PR DESCRIPTION
Reflection Probes import as empties in the normal glTF import, but the Reflection Probe component is only valid on Light Probes.  This PR changes it so that a Light Probe object with the correct location, rotation, and scale is added when importing the component and then parented to the empty.  The component is then imported onto the new Light Probe object instead of the empty.  No further parenting is attempted, so this should pose no danger to complex hierarchical relationships.

An issue with importing textures that I discovered when testing this PR has also been fixed.