### PR TITLE
Fix the import for the Loop Animation component's startOffset property.

### DIFF
--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -878,6 +878,10 @@ class LoopAnimation(HubsComponent):
                 tracks = property_value.split(",")
                 import_tracks(tracks, blender_ob, blender_component)
             else:
+                if property_name == 'startOffset':
+                    fps = bpy.context.scene.render.fps / bpy.context.scene.render.fps_base
+                    property_value = round(property_value * fps)
+
                 assign_property(gltf.vnodes, blender_component,
                                 property_name, property_value)
 


### PR DESCRIPTION
Convert the glTF property from seconds to frames before attempting to assign it to the Blender property.  Attempting to use the seconds directly led to python errors because the Blender property only accepts integers while the glTF property was usually a float.