### PR TITLE
Don't attempt to assign glTF properties to non-existent Blender properties.

### DIFF
--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -481,4 +481,6 @@ def assign_property(vnodes, blender_component, property_name, property_value):
         set_color_from_hex(blender_component, property_name, property_value)
 
     else:
+        if not hasattr(blender_component, property_name):
+            return
         setattr(blender_component, property_name, property_value)


### PR DESCRIPTION
Although assigning to non-existent Blender properties doesn't seem to cause any errors, this should prevent any unforeseen side-effects from cropping up.