### PR TITLE
Fix dependency installation error reporting and handling.

### DIFF
--- a/addons/io_hubs_addon/utils.py
+++ b/addons/io_hubs_addon/utils.py
@@ -35,25 +35,28 @@ def get_or_create_deps_path(name):
     return deps_path
 
 
-def is_module_available(name):
+def is_module_available(name, local_dependency=True):
     import sys
     old_syspath = sys.path[:]
     old_sysmod = sys.modules.copy()
 
     try:
-        path = get_or_create_deps_path(name)
+        if local_dependency:
+            path = get_or_create_deps_path(name)
+            sys.path.insert(0, str(path))
 
         import importlib
-        sys.path.insert(0, str(path))
-
         try:
             loader = importlib.util.find_spec(name)
         except ImportError as ex:
             print(f'{name} not found')
 
-        import os
-        path = os.path.join(path, name)
-        return loader and os.path.exists(path)
+        if local_dependency:
+            import os
+            path = os.path.join(path, name)
+            return bool(loader and os.path.exists(path))
+        else:
+            return bool(loader)
 
     finally:
         # Restore without assigning a new list instance. That way references


### PR DESCRIPTION
False positives in the error reporting when installing dependencies caused confusion to users and sometimes led to the dependency not getting installed at all when false errors were detected and the install halted.
Switch to relying solely on is_module_available to determine whether an install was successful and suppress errors unless they are 100% confirmed to be an issue.
Make upgrading pip optional instead of required.
Modify is_module_available to be able to check both system dependencies (i.e. pip) and locally installed dependencies.
Modify is_module_available to explicitly return a bool.

This PR should hopefully address #308 as well as any other similar cases.