### PR TITLE
Add Blender 4.2+ support for the import/export settings panels

### DIFF
--- a/addons/io_hubs_addon/__init__.py
+++ b/addons/io_hubs_addon/__init__.py
@@ -25,6 +25,30 @@ bl_info = {
 create_prefs_dir()
 
 
+# Blender 4.2+ glTF Extension Import/Export Settings Panel
+def draw(context, layout):
+    layout_header, layout_body = layout.panel('HBA_PT_Import_Export_Panel', default_closed=True)
+    sfile = context.space_data
+    operator = sfile.active_operator
+
+    # Panel Header
+    if operator.bl_idname == "EXPORT_SCENE_OT_gltf":
+        props = bpy.context.scene.HubsComponentsExtensionProperties
+    elif operator.bl_idname == "IMPORT_SCENE_OT_gltf":
+        props = bpy.context.scene.HubsComponentsExtensionImportProperties
+
+    layout_header.use_property_split = False
+    layout_header.prop(props, 'enabled', text="")
+    layout_header.label(text="Hubs Components")
+
+    # Panel Body
+    if layout_body:
+        if operator.bl_idname == "EXPORT_SCENE_OT_gltf":
+            gltf_exporter.HubsGLTFExportPanel.draw_body(context, layout_body)
+        elif operator.bl_idname == "IMPORT_SCENE_OT_gltf":
+            gltf_importer.HubsGLTFImportPanel.draw_body(context, layout_body)
+
+
 def register():
     icons.register()
     preferences.register()

--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -249,7 +249,10 @@ class HubsGLTFExportPanel(bpy.types.Panel):
         self.layout.prop(props, 'enabled', text="")
 
     def draw(self, context):
-        layout = self.layout
+        self.draw_body(context, self.layout)
+
+    @staticmethod
+    def draw_body(context, layout):
         layout.use_property_split = True
         layout.use_property_decorate = False  # No animation.
 

--- a/addons/io_hubs_addon/io/gltf_importer.py
+++ b/addons/io_hubs_addon/io/gltf_importer.py
@@ -298,7 +298,10 @@ class HubsGLTFImportPanel(bpy.types.Panel):
         self.layout.prop(props, 'enabled', text="")
 
     def draw(self, context):
-        layout = self.layout
+        self.draw_body(context, self.layout)
+
+    @staticmethod
+    def draw_body(context, layout):
         layout.use_property_split = True
         layout.use_property_decorate = False  # No animation.
 


### PR DESCRIPTION
The glTF add-on changed how it handles drawing the user extension settings panels for the import/export dialogs.  Now the glTF add-on searches for a single draw method (which handles both import and export) in the __init__.py file of the Hubs add-on where previously it provided a panel for the importer and exporter respectively that we could hook into.  This PR adds support for the new method while preserving support for the previous method.