### PR TITLE
Fix the Navigation Mesh component export for Blender 4.2

### DIFF
--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -157,7 +157,12 @@ def gather_properties(export_settings, object, component):
     if value:
         return value
     else:
-        return {"__empty_component_dummy": None}
+        # Hubs expects this to just be an empty dictionary, but the glTF exporter strips them out with its __fix_json function in gltf2_blender_export.py
+        # Add one dummy component per __fix_json call so that we end up with an empty dictionary.
+        if bpy.app.version < (4, 2, 0):
+            return {"__empty_component_dummy": None}
+        else:
+            return {"__empty_component_dummy": {"__empty_component_dummy": None}}
 
 
 def gather_property(export_settings, blender_object, target, property_name):


### PR DESCRIPTION
Add an extra dummy value to the Navigation Mesh component when exporting from Blender 4.2.
Hubs expects the value for the Navigation Mesh to be an empty dictionary, but the glTF exporter attempts to strip these out.
To combat this, the Hubs exporter uses a dummy value that gets stripped down to an empty dictionary by the glTF exporter, but in Blender 4.2 the glTF exporter added in an additional call to strip out empty values and ended up removing the component entirely.

Fixes https://github.com/Hubs-Foundation/hubs-blender-exporter/issues/311