### PR TITLE
Fix reflection probes not baking in Blender versions 4.0 and 4.1

### DIFF
--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -338,7 +338,7 @@ class BakeProbeOperator(Operator):
 
     def setup_probe_render(self, context):
         probe = self.probes[self.probe_index]
-        cycles_settings = self.camera_data.cycles if bpy.app.version < (4, 2, 0) else self.camera_data
+        cycles_settings = self.camera_data.cycles if bpy.app.version < (4, 0, 0) else self.camera_data
 
         self.camera_data.type = "PANO"
         cycles_settings.panorama_type = "EQUIRECTANGULAR"


### PR DESCRIPTION
The API for accessing certain cycles camera settings changed in Blender 4.0, but the code handling this was mistakenly set to use the new API for only 4.2+ instead of 4.0+.