### PR TITLE
Update glTF add-on imports to support Blender 4.3

### DIFF
--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -6,8 +6,8 @@ from ..components.utils import get_host_components
 import traceback
 
 if bpy.app.version < (3, 0, 0):
-    from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
     from io_scene_gltf2.blender.exp import gltf2_blender_export
+    from io_scene_gltf2.io.exp.gltf2_io_user_extensions import export_user_extensions
 
     # gather_gltf_hook does not expose the info we need, make a custom hook for now
     # ideally we can resolve this upstream somehow https://github.com/KhronosGroup/glTF-Blender-IO/issues/1009
@@ -73,15 +73,26 @@ def export_callback(callback_method, export_settings):
 
 
 def glTF2_pre_export_callback(export_settings):
-    from io_scene_gltf2.blender.com.gltf2_blender_extras import BLACK_LIST
+    # Import BLACK_LIST here instead of at the beginning of the file to make sure we're always referencing the same one as the glTF add-on.
+    # https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/166#issuecomment-1335083605
+    if bpy.app.version >= (4, 3, 0):
+        from io_scene_gltf2.blender.com.extras import BLACK_LIST
+    else:
+        from io_scene_gltf2.blender.com.gltf2_blender_extras import BLACK_LIST
+
     BLACK_LIST.extend(glTF2ExportUserExtension.EXCLUDED_PROPERTIES)
     export_callback("pre_export", export_settings)
 
 
 def glTF2_post_export_callback(export_settings):
-    export_callback("post_export", export_settings)
+    # Import BLACK_LIST here instead of at the beginning of the file to make sure we're always referencing the same one as the glTF add-on.
+    # https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/166#issuecomment-1335083605
+    if bpy.app.version >= (4, 3, 0):
+        from io_scene_gltf2.blender.com.extras import BLACK_LIST
+    else:
+        from io_scene_gltf2.blender.com.gltf2_blender_extras import BLACK_LIST
 
-    from io_scene_gltf2.blender.com.gltf2_blender_extras import BLACK_LIST
+    export_callback("post_export", export_settings)
     for excluded_prop in glTF2ExportUserExtension.EXCLUDED_PROPERTIES:
         if excluded_prop in BLACK_LIST:
             BLACK_LIST.remove(excluded_prop)

--- a/addons/io_hubs_addon/io/gltf_importer.py
+++ b/addons/io_hubs_addon/io/gltf_importer.py
@@ -1,12 +1,20 @@
 import bpy
-from bpy.props import BoolProperty, PointerProperty
-from io_scene_gltf2.blender.imp.gltf2_blender_node import BlenderNode
-from io_scene_gltf2.blender.imp.gltf2_blender_material import BlenderMaterial
-from io_scene_gltf2.blender.imp.gltf2_blender_scene import BlenderScene
-from io_scene_gltf2.blender.imp.gltf2_blender_image import BlenderImage
+import traceback
 from .utils import HUBS_CONFIG, import_image, import_all_textures
 from ..components.components_registry import get_component_by_name
-import traceback
+from bpy.props import BoolProperty, PointerProperty
+
+# Version-specific imports
+if bpy.app.version >= (4, 3, 0):
+    from io_scene_gltf2.blender.imp.image import BlenderImage
+    from io_scene_gltf2.blender.imp.node import BlenderNode
+    from io_scene_gltf2.blender.imp.material import BlenderMaterial
+    from io_scene_gltf2.blender.imp.scene import BlenderScene
+else:
+    from io_scene_gltf2.blender.imp.gltf2_blender_image import BlenderImage
+    from io_scene_gltf2.blender.imp.gltf2_blender_node import BlenderNode
+    from io_scene_gltf2.blender.imp.gltf2_blender_material import BlenderMaterial
+    from io_scene_gltf2.blender.imp.gltf2_blender_scene import BlenderScene
 
 EXTENSION_NAME = HUBS_CONFIG["gltfExtensionName"]
 

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -1,25 +1,71 @@
-import os
 import bpy
-from io_scene_gltf2.blender.com import gltf2_blender_extras
-if bpy.app.version >= (3, 6, 0):
-    from io_scene_gltf2.blender.exp import gltf2_blender_gather_nodes, gltf2_blender_gather_joints
-    from io_scene_gltf2.blender.exp.material import gltf2_blender_gather_materials, gltf2_blender_gather_texture_info
-    from io_scene_gltf2.blender.exp.material.extensions import gltf2_blender_image
-else:
-    from io_scene_gltf2.blender.exp import gltf2_blender_gather_materials, gltf2_blender_gather_nodes, gltf2_blender_gather_joints
-    from io_scene_gltf2.blender.exp import gltf2_blender_gather_texture_info, gltf2_blender_export_keys
-    from io_scene_gltf2.blender.exp import gltf2_blender_image
-from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
-if bpy.app.version >= (4, 1, 0):
-    from io_scene_gltf2.blender.exp.material import gltf2_blender_search_node_tree
+import os
+import re
+from ..nodes.lightmap import MozLightmapNode
 from io_scene_gltf2.io.com import gltf2_io_extensions
 from io_scene_gltf2.io.com import gltf2_io
-from io_scene_gltf2.io.exp import gltf2_io_binary_data
-from io_scene_gltf2.io.exp import gltf2_io_image_data
-from io_scene_gltf2.blender.imp.gltf2_blender_image import BlenderImage
 from typing import Optional, Tuple, Union
-from ..nodes.lightmap import MozLightmapNode
-import re
+
+# Version-specific imports
+if bpy.app.version >= (4, 3, 0):
+    from io_scene_gltf2.blender.com import extras as gltf2_blender_extras
+    from io_scene_gltf2.blender.exp import joints as gltf2_blender_gather_joints
+    from io_scene_gltf2.blender.exp import nodes as gltf2_blender_gather_nodes
+    from io_scene_gltf2.blender.exp.cache import cached
+    from io_scene_gltf2.blender.exp.material import encode_image as gltf2_blender_image
+    from io_scene_gltf2.blender.exp.material import materials as gltf2_blender_gather_materials
+    from io_scene_gltf2.blender.exp.material import search_node_tree as gltf2_blender_search_node_tree
+    from io_scene_gltf2.blender.exp.material import texture_info as gltf2_blender_gather_texture_info
+    from io_scene_gltf2.blender.imp.image import BlenderImage
+    from io_scene_gltf2.io.exp import binary_data as gltf2_io_binary_data
+    from io_scene_gltf2.io.exp import image_data as gltf2_io_image_data
+elif bpy.app.version >= (4, 1, 0):
+    from io_scene_gltf2.blender.com import gltf2_blender_extras
+    # import the gather_nodes before the gather_joints to avoid a circular import specific to Blender 4.1
+    from io_scene_gltf2.blender.exp import (
+        gltf2_blender_gather_nodes,
+        gltf2_blender_gather_joints
+    )
+    from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+    from io_scene_gltf2.blender.exp.material import (
+        gltf2_blender_gather_materials,
+        gltf2_blender_search_node_tree,
+        gltf2_blender_gather_texture_info
+    )
+    from io_scene_gltf2.blender.exp.material.extensions import gltf2_blender_image
+    from io_scene_gltf2.blender.imp.gltf2_blender_image import BlenderImage
+    from io_scene_gltf2.io.exp import gltf2_io_binary_data
+    from io_scene_gltf2.io.exp import gltf2_io_image_data
+elif bpy.app.version >= (3, 6, 0):
+    from io_scene_gltf2.blender.com import gltf2_blender_extras
+    from io_scene_gltf2.blender.exp import (
+        gltf2_blender_gather_joints,
+        gltf2_blender_gather_nodes
+    )
+    from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+    from io_scene_gltf2.blender.exp.material import (
+        gltf2_blender_gather_materials,
+        gltf2_blender_gather_texture_info
+    )
+    from io_scene_gltf2.blender.exp.material.extensions import gltf2_blender_image
+    from io_scene_gltf2.blender.imp.gltf2_blender_image import BlenderImage
+    from io_scene_gltf2.io.exp import gltf2_io_binary_data
+    from io_scene_gltf2.io.exp import gltf2_io_image_data
+else:
+    from io_scene_gltf2.blender.com import gltf2_blender_extras
+    from io_scene_gltf2.blender.exp import (
+        gltf2_blender_export_keys,
+        gltf2_blender_image,
+        gltf2_blender_gather_materials,
+        gltf2_blender_gather_joints,
+        gltf2_blender_gather_nodes,
+        gltf2_blender_gather_texture_info
+    )
+    from io_scene_gltf2.blender.exp.gltf2_blender_gather_cache import cached
+    from io_scene_gltf2.blender.imp.gltf2_blender_image import BlenderImage
+    from io_scene_gltf2.io.exp import gltf2_io_binary_data
+    from io_scene_gltf2.io.exp import gltf2_io_image_data
+
 
 HUBS_CONFIG = {
     "gltfExtensionName": "MOZ_hubs_components",


### PR DESCRIPTION
A lot of the files in the glTF add-on were renamed to be shorter to better accommodate the path length limit in Windows for the Blender 4.3 release (https://github.com/KhronosGroup/glTF-Blender-IO/pull/2331).  This prevents the Hubs add-on from loading at all because many of the previous imports are no longer valid.

This PR fixes the imports and restructures the glTF add-on imports so that imports common to all versions are done first, then each Blender version has a section for the rest of it's imports from the glTF add-on. This results in some duplication of imports, but keeps things clear and simple.

Cleanup:
* Several imports from the same file have been combined into a single import.
* Imports at the beginning of the file have been ordered alphabetically (mostly).
* Imports at the beginning of the file with the format `from x import y` have been placed after imports with the format `import x`.
* One of the`BLACK_LIST` imports has been moved to the top of its function to be more readable with its increase in complexity.
* Added a comment to describe why `BLACK_LIST` is imported in a function instead of at the beginning of the file.