### PR TITLE
Support the new __init__ method requirements for Blender 4.4

### DIFF
--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -100,7 +100,8 @@ class HubsComponent(PropertyGroup):
     def is_dep_only(cls):
         return not cls.get_category()
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if type(self) is HubsComponent:
             raise Exception(
                 'HubsComponent is an abstract class and cannot be instantiated directly')


### PR DESCRIPTION
## What?
Updates the `__init__` method in the HubsComponent class to call the `__init__` method of the parent Blender class.

## Why?
Blender 4.4 requires that any subclasses of Blender classes with an `__init__` method must call the `__init__` method of the Blender class and pass along any arguments it received.
See: https://developer.blender.org/docs/release_notes/4.4/python_api/#subclassing-blender-types

## How to test

1. Open Blender from a terminal (or if you're in Windows toggle the system console after Blender has started).
2. Load a Blender file that contains Hubs components or add a Hubs component to an object.
3. Check the terminal for any of the following errors:
    `MemoryError: couldn't create bpy_struct object`