### PR TITLE
Update upload-artifact version to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -101,7 +101,7 @@ jobs:
           cd tests
           OUT_PREFIX=$GITHUB_WORKSPACE/tests/out yarn test-bail --reporter-options reportDir=out/mochawesome
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-output-${{ matrix.version }}
           path: tests/out/mochawesome
@@ -122,8 +122,9 @@ jobs:
           VERSION=$(grep '"version"' $GITHUB_WORKSPACE/addons/io_hubs_addon/__init__.py | sed -E 's/.*\(([0-9]+), ([0-9]+), ([0-9]+), ([0-9]+)\).*/\1.\2.\3.\4/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Upload addon artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: io_hubs_addon_${{ steps.get_version.outputs.version }}
           path: addons
           if-no-files-found: error
+          include-hidden-files: true


### PR DESCRIPTION
## What?
<!-- Explain what your pull request does -->
Updates the publish.yml file to use version 4 of upload-artifact.
Adds the include-hidden-files parameter to maintain parity with the old version.

## Why?
<!-- Explain why you're opening this pull request, what limitations does it address, etc..  If you're addressing an open issue you can often just link to the issue -->
upload-artifact version 3 is no longer supported in GitHub actions and causes the action to fail.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Examples
<!-- If applicable, give examples of your changes, screenshots, videos, etc. -->
N/A

## How to test
<!-- Give the steps required to test your pull request -->

1. Upload the changes from this PR to your own fork.
2. Run the publish action (this will likely happen automatically when you push the changes..
3. Review the run for the publish action.

## Documentation of functionality
<!-- Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
None needed.

## Limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
None known.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
None
