### PR TITLE
Tooltips from component classes

### DIFF
--- a/addons/io_hubs_addon/components/definitions/ambient_light.py
+++ b/addons/io_hubs_addon/components/definitions/ambient_light.py
@@ -11,7 +11,8 @@ class AmbientLight(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_HEMI',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'A light that illuminates all objects in the scene',
     }
 
     color: FloatVectorProperty(name="Color",

--- a/addons/io_hubs_addon/components/definitions/ammo_shape.py
+++ b/addons/io_hubs_addon/components/definitions/ammo_shape.py
@@ -12,7 +12,8 @@ class AmmoShape(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'SCENE_DATA',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': '[DEPRECATED?] Define the physics shape of an entity',
     }
 
     type: EnumProperty(

--- a/addons/io_hubs_addon/components/definitions/audio.py
+++ b/addons/io_hubs_addon/components/definitions/audio.py
@@ -15,7 +15,8 @@ class Audio(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],
         'icon': 'OUTLINER_OB_SPEAKER',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Load an audio file from a URL and play it.'
     }
 
     src: StringProperty(

--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -19,7 +19,8 @@ class AudioParams(HubsComponent):
         'display_name': 'Audio Params',
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
-        'version': (1, 0, 1)
+        'version': (1, 0, 1),
+        'tooltip': 'Define audio drop off settings',
     }
 
     overrideAudioSettings: BoolProperty(

--- a/addons/io_hubs_addon/components/definitions/audio_settings.py
+++ b/addons/io_hubs_addon/components/definitions/audio_settings.py
@@ -16,7 +16,8 @@ class AudioSettings(HubsComponent):
         'node_type': NodeType.SCENE,
         'panel_type': [PanelType.SCENE],
         'icon': 'SPEAKER',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Define audio settings for the scene'
     }
 
     avatarDistanceModel: EnumProperty(

--- a/addons/io_hubs_addon/components/definitions/audio_source.py
+++ b/addons/io_hubs_addon/components/definitions/audio_source.py
@@ -12,7 +12,7 @@ class AudioSource(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MOD_WAVE',
         'version': (1, 0, 0),
-        'tooltip': 'Play audio when an avatar enters a zone',
+        'tooltip': 'Difine settings for an audio source attached to this object.',
     }
 
     onlyMods: BoolProperty(

--- a/addons/io_hubs_addon/components/definitions/audio_source.py
+++ b/addons/io_hubs_addon/components/definitions/audio_source.py
@@ -11,7 +11,8 @@ class AudioSource(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MOD_WAVE',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Play audio when an avatar enters a zone',
     }
 
     onlyMods: BoolProperty(

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -82,7 +82,8 @@ class AudioTarget(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['audio-params'],
         'icon': 'SPEAKER',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'A component that plays audio based on the distance between two entities'
     }
 
     srcNode: PointerProperty(

--- a/addons/io_hubs_addon/components/definitions/audio_zone.py
+++ b/addons/io_hubs_addon/components/definitions/audio_zone.py
@@ -15,7 +15,8 @@ class AudioZone(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],
         'icon': 'MATCUBE',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Create an audio zone to control audio parameters within a specific area.'
     }
 
     inOut: BoolProperty(

--- a/addons/io_hubs_addon/components/definitions/billboard.py
+++ b/addons/io_hubs_addon/components/definitions/billboard.py
@@ -11,7 +11,8 @@ class Billboard(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'IMAGE_PLANE',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Make this object always face the camera'
     }
 
     onlyY: BoolProperty(

--- a/addons/io_hubs_addon/components/definitions/directional_light.py
+++ b/addons/io_hubs_addon/components/definitions/directional_light.py
@@ -13,7 +13,8 @@ class DirectionalLight(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_SUN',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'A light that emits parallel light in a specific direction, like the sun',
     }
 
     color: FloatVectorProperty(name="Color",

--- a/addons/io_hubs_addon/components/definitions/environment_settings.py
+++ b/addons/io_hubs_addon/components/definitions/environment_settings.py
@@ -27,7 +27,8 @@ class EnvironmentSettings(HubsComponent):
         'node_type': NodeType.SCENE,
         'panel_type': [PanelType.SCENE],
         'icon': 'WORLD',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip':  'Define Background image and Evnironment settings',
     }
 
     toneMapping: EnumProperty(

--- a/addons/io_hubs_addon/components/definitions/fog.py
+++ b/addons/io_hubs_addon/components/definitions/fog.py
@@ -11,7 +11,8 @@ class Fog(HubsComponent):
         'node_type': NodeType.SCENE,
         'panel_type': [PanelType.SCENE],
         'icon': 'MOD_OCEAN',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Add fog to the scene',
     }
 
     def draw(self, context, layout, panel):

--- a/addons/io_hubs_addon/components/definitions/frustrum.py
+++ b/addons/io_hubs_addon/components/definitions/frustrum.py
@@ -11,7 +11,8 @@ class Frustrum(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'IMAGE_PLANE',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'A component that defines a frustrum'
     }
 
     culled: BoolProperty(

--- a/addons/io_hubs_addon/components/definitions/hemisphere_light.py
+++ b/addons/io_hubs_addon/components/definitions/hemisphere_light.py
@@ -11,7 +11,8 @@ class HemisphereLight(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_AREA',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Add a hemispherical light, similar to a skydome'
     }
 
     skyColor: FloatVectorProperty(name="Sky Color",

--- a/addons/io_hubs_addon/components/definitions/image.py
+++ b/addons/io_hubs_addon/components/definitions/image.py
@@ -16,7 +16,8 @@ class Image(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'FILE_IMAGE',
         'deps': ['networked'],
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Displays an image from a URL'
     }
 
     src: StringProperty(

--- a/addons/io_hubs_addon/components/definitions/link.py
+++ b/addons/io_hubs_addon/components/definitions/link.py
@@ -15,7 +15,8 @@ class Link(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LINKED',
         'deps': ['networked'],
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Create an interactable hyperlink'
     }
 
     href: StringProperty(name="Link URL", description="Link URL",

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -760,7 +760,8 @@ class LoopAnimation(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LOOP_BACK',
-        'version': (1, 1, 0)
+        'version': (1, 1, 0),
+        'tooltip': 'Play a looping animation on the object or bone',
     }
 
     tracks_list: CollectionProperty(

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -57,7 +57,8 @@ class MediaFrame(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'OBJECT_DATA',
         'deps': ['networked'],
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Add media like images, PDFs, and videos'
     }
 
     mediaType: EnumProperty(

--- a/addons/io_hubs_addon/components/definitions/mirror.py
+++ b/addons/io_hubs_addon/components/definitions/mirror.py
@@ -14,7 +14,8 @@ class Mirror(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MOD_MIRROR',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Adds a planar mirror to the room'
     }
 
     color: FloatVectorProperty(name="Color",

--- a/addons/io_hubs_addon/components/definitions/model.py
+++ b/addons/io_hubs_addon/components/definitions/model.py
@@ -13,7 +13,8 @@ class Model(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'SCENE_DATA',
         'deps': ['networked'],
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Loads a 3D model (glb) from a URL'
     }
 
     src: StringProperty(name="Model URL", description="Model URL",

--- a/addons/io_hubs_addon/components/definitions/morph_audio_feedback.py
+++ b/addons/io_hubs_addon/components/definitions/morph_audio_feedback.py
@@ -66,7 +66,8 @@ class MorphAudioFeedback(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'MOD_SMOOTH',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Control a shapekey for an avatar based on mic volume'
     }
 
     name: StringProperty(

--- a/addons/io_hubs_addon/components/definitions/nav_mesh.py
+++ b/addons/io_hubs_addon/components/definitions/nav_mesh.py
@@ -12,7 +12,8 @@ class NavMesh(HubsComponent):
         'panel_type': [PanelType.OBJECT],
         'icon': 'GRID',
         'version': (1, 0, 1),
-        'deps': ['visible']
+        'deps': ['visible'],
+        'tooltip': 'A navmesh defines the area where avatars can walk'
     }
 
     @classmethod

--- a/addons/io_hubs_addon/components/definitions/particle_emitter.py
+++ b/addons/io_hubs_addon/components/definitions/particle_emitter.py
@@ -18,7 +18,8 @@ class ParticleEmitter(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'PARTICLES',
-        'version': (1, 1, 0)
+        'version': (1, 1, 0),
+        'tooltip': 'Emit particles from this object'
     }
 
     particleCount: IntProperty(

--- a/addons/io_hubs_addon/components/definitions/pdf.py
+++ b/addons/io_hubs_addon/components/definitions/pdf.py
@@ -14,7 +14,8 @@ class PDF(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked'],
         'icon': 'FILE_IMAGE',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Load a PDF from a URL and show it in the scene.'
     }
     src: StringProperty(
         name="PDF URL", description="The web address of the PDF", default='https://example.org/PdfFile.pdf')

--- a/addons/io_hubs_addon/components/definitions/personal_space_invader.py
+++ b/addons/io_hubs_addon/components/definitions/personal_space_invader.py
@@ -11,7 +11,8 @@ class PersonalSpaceInvader(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MATSHADERBALL',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Fade out other avatars if they get too close'
     }
 
     radius: FloatProperty(name="Radius",

--- a/addons/io_hubs_addon/components/definitions/point_light.py
+++ b/addons/io_hubs_addon/components/definitions/point_light.py
@@ -13,7 +13,8 @@ class PointLight(HubsComponent):
         'node_type': NodeType. NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_POINT',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Add a point light'
     }
 
     color: FloatVectorProperty(name="Color",

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -654,7 +654,8 @@ class ReflectionProbe(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'MATERIAL',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'A reflection probe is a type of light probe that captures the environment around it and uses that information to create reflections on objects in the scene',
     }
 
     envMapTexture: PointerProperty(

--- a/addons/io_hubs_addon/components/definitions/scale_audio_feedback.py
+++ b/addons/io_hubs_addon/components/definitions/scale_audio_feedback.py
@@ -11,7 +11,8 @@ class ScaleAudioFeedback(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'GRAPH',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Control the scale of an object or bone based on mic volume'
     }
 
     minScale: FloatProperty(name="Min Scale",

--- a/addons/io_hubs_addon/components/definitions/scene_preview_camera.py
+++ b/addons/io_hubs_addon/components/definitions/scene_preview_camera.py
@@ -77,7 +77,8 @@ class ScenePreviewCamera(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'CAMERA_DATA',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Define a camera for rendering a preview of the scene'
     }
 
     fov: FloatProperty(name="FOV", min=0, max=radians(180), default=radians(80), subtype="ANGLE", unit="ROTATION")

--- a/addons/io_hubs_addon/components/definitions/shadow.py
+++ b/addons/io_hubs_addon/components/definitions/shadow.py
@@ -11,7 +11,8 @@ class Shadow(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'MOD_MASK',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Make this object cast dynamic shadows'
     }
 
     cast: BoolProperty(

--- a/addons/io_hubs_addon/components/definitions/simple_water.py
+++ b/addons/io_hubs_addon/components/definitions/simple_water.py
@@ -11,7 +11,8 @@ class SimpleWater(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MOD_FLUIDSIM',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Add an animated water surface to your scene'
     }
 
     color: FloatVectorProperty(name="Color",

--- a/addons/io_hubs_addon/components/definitions/skybox.py
+++ b/addons/io_hubs_addon/components/definitions/skybox.py
@@ -11,7 +11,8 @@ class Skybox(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MAT_SPHERE_SKY',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Creates a procedural sky'
     }
 
     azimuth: FloatProperty(name="Time of Day",

--- a/addons/io_hubs_addon/components/definitions/spawner.py
+++ b/addons/io_hubs_addon/components/definitions/spawner.py
@@ -13,7 +13,8 @@ class Spawner(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'MOD_PARTICLE_INSTANCE',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Spawn objects (glb) loaded from a URL by dragging'
     }
 
     src: StringProperty(

--- a/addons/io_hubs_addon/components/definitions/spot_light.py
+++ b/addons/io_hubs_addon/components/definitions/spot_light.py
@@ -14,7 +14,8 @@ class SpotLight(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'LIGHT_SPOT',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Add a spot light'
     }
 
     color: FloatVectorProperty(name="Color",

--- a/addons/io_hubs_addon/components/definitions/text.py
+++ b/addons/io_hubs_addon/components/definitions/text.py
@@ -15,7 +15,8 @@ class Text(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'FONT_DATA',
-        'version': (1, 1, 0)
+        'version': (1, 1, 0),
+        'tooltip': 'Show customizable text in 3D space'
     }
 
     value: StringProperty(

--- a/addons/io_hubs_addon/components/definitions/uv_scroll.py
+++ b/addons/io_hubs_addon/components/definitions/uv_scroll.py
@@ -11,7 +11,8 @@ class UVScroll(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT],
         'icon': 'TEXTURE_DATA',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Scroll the UVs of a material, generating an infinite scrolling effect'
     }
 
     speed: FloatVectorProperty(name="Speed",

--- a/addons/io_hubs_addon/components/definitions/video.py
+++ b/addons/io_hubs_addon/components/definitions/video.py
@@ -16,7 +16,8 @@ class Video(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'deps': ['networked', 'audio-params'],
         'icon': 'FILE_MOVIE',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'Play a video from a URL'
     }
 
     src: StringProperty(

--- a/addons/io_hubs_addon/components/definitions/video_texture_source.py
+++ b/addons/io_hubs_addon/components/definitions/video_texture_source.py
@@ -12,7 +12,8 @@ class VideoTextureSource(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'VIEW_CAMERA',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'A component that uses a video like a texture'
     }
 
     resolution: IntVectorProperty(name="Resolution",

--- a/addons/io_hubs_addon/components/definitions/visible.py
+++ b/addons/io_hubs_addon/components/definitions/visible.py
@@ -12,7 +12,8 @@ class Visible(HubsComponent):
         'node_type': NodeType.NODE,
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'HIDE_OFF',
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': 'hide this object from the camrera'
     }
 
-    visible: BoolProperty(name="Visible", default=True)
+    visible: BoolProperty(name="Visible", default=False)

--- a/addons/io_hubs_addon/components/definitions/visible.py
+++ b/addons/io_hubs_addon/components/definitions/visible.py
@@ -13,7 +13,7 @@ class Visible(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'icon': 'HIDE_OFF',
         'version': (1, 0, 0),
-        'tooltip': 'hide this object from the camrera'
+        'tooltip': 'Hide this object from the camrera'
     }
 
     visible: BoolProperty(name="Visible", default=False)

--- a/addons/io_hubs_addon/components/definitions/waypoint.py
+++ b/addons/io_hubs_addon/components/definitions/waypoint.py
@@ -16,7 +16,8 @@ class Waypoint(HubsComponent):
         'gizmo': 'waypoint',
         'icon': 'spawn-point.png',
         'deps': ['networked'],
-        'version': (1, 0, 0)
+        'version': (1, 0, 0),
+        'tooltip': "Add a waypoint to teleport to, can also be a spawn point"
     }
 
     canBeSpawnPoint: BoolProperty(

--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -3,7 +3,6 @@ from bpy.props import IntVectorProperty
 from .types import Category, PanelType, NodeType
 from ..io.utils import import_component, assign_property
 
-
 class HubsComponent(PropertyGroup):
     _definition = {
         # The name that will be used in the glTF file MOZ_hubs_components object when exporting the component.
@@ -21,7 +20,9 @@ class HubsComponent(PropertyGroup):
         # Name of the icon to load. It can be a image file in the icons directory or one of the Blender builtin icons id
         'icon': 'icon.png',
         # Version of the component. This will be used to trigger component migrations.
-        'version': (0, 0, 1)
+        'version': (0, 0, 1),
+        # tooltip to be displayed on mouse over button
+        'tooltip': 'Tooltip template',
     }
 
     # Properties defined here are for internal use and won't be displayed by default in components or exported.

--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -170,6 +170,10 @@ class HubsComponent(PropertyGroup):
         return True
 
     @classmethod
+    def get_tooltip(cls):
+        return cls.__get_definition('tooltip', None)
+
+    @classmethod
     def get_unsupported_host_message(cls, panel_type, host, ob=None):
         '''This method will return the message to use if this component isn't supported on this host.
         This is currently called during migrations.

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -12,7 +12,7 @@ from .gizmos import update_gizmos
 from .utils import is_linked, redraw_component_ui
 from ..icons import get_hubs_icons
 import os
-
+from .definitions import component_tooltips
 
 class AddHubsComponent(Operator):
     bl_idname = "wm.add_hubs_component"
@@ -52,9 +52,21 @@ class AddHubsComponent(Operator):
                         cls.poll_message_set(
                             "Cannot add components to linked bones")
                     return False
-
         return True
-
+    
+    @classmethod
+    def description(cls, context, properties):
+        component = properties.component_name
+        if component == '':
+            panel_type = None
+            for item in properties.items():
+                _, panel_type = item
+            tooltip = "Add a hubs component to this object" if panel_type == "object" \
+                else "Add a hubs component to the scene" if panel_type == "scene" \
+                else "Add a hubs component to this bone" 
+            return tooltip
+        return component_tooltips.component_descriptions[component]
+    
     def execute(self, context):
         if self.component_name == '':
             return
@@ -164,6 +176,7 @@ class AddHubsComponent(Operator):
                                         icon_value=hubs_icons[icon].icon_id)
                                     op.component_name = component_name
                                     op.panel_type = panel_type
+                                    print(". exists:", AddHubsComponent.bl_idname)
                             else:
                                 if has_component(obj, component_name):
                                     op = column.label(
@@ -173,6 +186,8 @@ class AddHubsComponent(Operator):
                                         AddHubsComponent.bl_idname, text=component_display_name, icon=icon)
                                     op.component_name = component_name
                                     op.panel_type = panel_type
+                                    print("no dot:", AddHubsComponent.bl_idname)
+
                         else:
                             if has_component(obj, component_name):
                                 op = column.label(text=component_display_name)
@@ -181,6 +196,8 @@ class AddHubsComponent(Operator):
                                     AddHubsComponent.bl_idname, text=component_display_name, icon='ADD')
                                 op.component_name = component_name
                                 op.panel_type = panel_type
+                                print("no icon:", AddHubsComponent.bl_idname)
+
 
                         added_comps += 1
 

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -11,8 +11,8 @@ from .handlers import migrate_components
 from .gizmos import update_gizmos
 from .utils import is_linked, redraw_component_ui
 from ..icons import get_hubs_icons
+from .components_registry import get_component_by_name
 import os
-from .definitions import component_tooltips
 
 class AddHubsComponent(Operator):
     bl_idname = "wm.add_hubs_component"
@@ -65,7 +65,10 @@ class AddHubsComponent(Operator):
                 else "Add a hubs component to the scene" if panel_type == "scene" \
                 else "Add a hubs component to this bone" 
             return tooltip
-        return component_tooltips.component_descriptions[component]
+        component_class = get_component_by_name(component)
+        print("component:", component)
+        print("component_class:", component_class, "type:", type(component_class))
+        return component_class.get_tooltip()
     
     def execute(self, context):
         if self.component_name == '':

--- a/addons/io_hubs_addon/components/operators.py
+++ b/addons/io_hubs_addon/components/operators.py
@@ -66,8 +66,6 @@ class AddHubsComponent(Operator):
                 else "Add a hubs component to this bone" 
             return tooltip
         component_class = get_component_by_name(component)
-        print("component:", component)
-        print("component_class:", component_class, "type:", type(component_class))
         return component_class.get_tooltip()
     
     def execute(self, context):
@@ -179,7 +177,6 @@ class AddHubsComponent(Operator):
                                         icon_value=hubs_icons[icon].icon_id)
                                     op.component_name = component_name
                                     op.panel_type = panel_type
-                                    print(". exists:", AddHubsComponent.bl_idname)
                             else:
                                 if has_component(obj, component_name):
                                     op = column.label(
@@ -189,8 +186,6 @@ class AddHubsComponent(Operator):
                                         AddHubsComponent.bl_idname, text=component_display_name, icon=icon)
                                     op.component_name = component_name
                                     op.panel_type = panel_type
-                                    print("no dot:", AddHubsComponent.bl_idname)
-
                         else:
                             if has_component(obj, component_name):
                                 op = column.label(text=component_display_name)
@@ -199,8 +194,6 @@ class AddHubsComponent(Operator):
                                     AddHubsComponent.bl_idname, text=component_display_name, icon='ADD')
                                 op.component_name = component_name
                                 op.panel_type = panel_type
-                                print("no icon:", AddHubsComponent.bl_idname)
-
 
                         added_comps += 1
 

--- a/addons/io_hubs_addon/components/ui.py
+++ b/addons/io_hubs_addon/components/ui.py
@@ -25,12 +25,11 @@ def draw_component(panel, context, obj, row, component_item):
             remove_component_operator = top_row.operator(
                 "wm.remove_hubs_component",
                 text="",
-                icon="X",
-                
+                icon="X"
             )
             remove_component_operator.component_name = component_name
             remove_component_operator.panel_type = panel.bl_context
-            return 
+            return
 
         component_id = component_class.get_id()
         component = getattr(obj, component_id)

--- a/addons/io_hubs_addon/components/ui.py
+++ b/addons/io_hubs_addon/components/ui.py
@@ -25,11 +25,12 @@ def draw_component(panel, context, obj, row, component_item):
             remove_component_operator = top_row.operator(
                 "wm.remove_hubs_component",
                 text="",
-                icon="X"
+                icon="X",
+                
             )
             remove_component_operator.component_name = component_name
             remove_component_operator.panel_type = panel.bl_context
-            return
+            return 
 
         component_id = component_class.get_id()
         component = getattr(obj, component_id)


### PR DESCRIPTION
## What?
Adds tooltips to the add hubs component operator

## Why?
Feature request

## Examples
Any hubs component on scene, objects or bones.

## How to test
Hover with your mouse over an Add Component button and then over one of the components that can be added from the menu.

## Open questions
I'm not a native speaker and am not sure if I described all components accurately. Feedback / corrections are appreciated.
