### PR TITLE
Add notifications for unrecognized properties on import

### DIFF
--- a/addons/io_hubs_addon/components/definitions/audio_params.py
+++ b/addons/io_hubs_addon/components/definitions/audio_params.py
@@ -151,5 +151,6 @@ class AudioParams(HubsComponent):
         for property_name, property_value in component_value.items():
             if property_name in ['coneInnerAngle', 'coneOuterAngle']:
                 property_value = radians(property_value)
-            assign_property(gltf.vnodes, component,
-                            property_name, property_value)
+            assign_property(gltf.vnodes,
+                            blender_host, component,
+                            property_name, property_value, import_report)

--- a/addons/io_hubs_addon/components/definitions/audio_settings.py
+++ b/addons/io_hubs_addon/components/definitions/audio_settings.py
@@ -136,5 +136,6 @@ class AudioSettings(HubsComponent):
         for property_name, property_value in component_value.items():
             if property_name in ['mediaConeInnerAngle', 'mediaConeOuterAngle']:
                 property_value = radians(property_value)
-            assign_property(gltf.vnodes, component,
-                            property_name, property_value)
+            assign_property(gltf.vnodes,
+                            blender_host, component,
+                            property_name, property_value, import_report)

--- a/addons/io_hubs_addon/components/definitions/audio_target.py
+++ b/addons/io_hubs_addon/components/definitions/audio_target.py
@@ -184,5 +184,6 @@ class AudioTarget(HubsComponent):
             if property_name == "srcNode" and type(property_value) is int:
                 # This srcNode property was generated from an older version of the exporter which stored the index directly as an integer.
                 property_value = {"__mhc_link_type": "node", "index": property_value}
-            assign_property(gltf.vnodes, component,
-                            property_name, property_value)
+            assign_property(gltf.vnodes,
+                            blender_host, component,
+                            property_name, property_value, import_report)

--- a/addons/io_hubs_addon/components/definitions/environment_settings.py
+++ b/addons/io_hubs_addon/components/definitions/environment_settings.py
@@ -170,9 +170,11 @@ class EnvironmentSettings(HubsComponent):
         for property_name, property_value in component_value.items():
             if property_name == "bloom":
                 for subproperty_name, subproperty_value in property_value.items():
-                    assign_property(gltf.vnodes, component,
+                    assign_property(gltf.vnodes,
+                                    blender_host, component,
                                     f"bloom{subproperty_name.capitalize()}",
-                                    subproperty_value)
+                                    subproperty_value, import_report)
             else:
-                assign_property(gltf.vnodes, component,
-                                property_name, property_value)
+                assign_property(gltf.vnodes,
+                                blender_host, component,
+                                property_name, property_value, import_report)

--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -958,8 +958,9 @@ class LoopAnimation(HubsComponent):
                     fps = bpy.context.scene.render.fps / bpy.context.scene.render.fps_base
                     property_value = round(property_value * fps)
 
-                assign_property(gltf.vnodes, blender_component,
-                                property_name, property_value)
+                assign_property(gltf.vnodes,
+                                blender_host, blender_component,
+                                property_name, property_value, import_report, blender_ob=blender_ob)
 
     def migrate(self, migration_type, panel_type, instance_version, host, migration_report, ob=None):
         migration_occurred = False

--- a/addons/io_hubs_addon/components/definitions/media_frame.py
+++ b/addons/io_hubs_addon/components/definitions/media_frame.py
@@ -218,8 +218,9 @@ class MediaFrame(HubsComponent):
             if property_name == 'bounds' and gltf_yup:
                 property_value['y'], property_value['z'] = property_value['z'], property_value['y']
 
-                assign_property(gltf.vnodes, blender_component,
-                                property_name, property_value)
+                assign_property(gltf.vnodes,
+                                blender_host, blender_component,
+                                property_name, property_value, import_report)
 
             elif property_name == 'align':
                 align = {
@@ -236,8 +237,9 @@ class MediaFrame(HubsComponent):
                 blender_component.alignZ = align['z']
 
             else:
-                assign_property(gltf.vnodes, blender_component,
-                                property_name, property_value)
+                assign_property(gltf.vnodes,
+                                blender_host, blender_component,
+                                property_name, property_value, import_report)
 
         if get_host_or_parents_scaled(blender_host):
             import_report.append(

--- a/addons/io_hubs_addon/components/definitions/networked.py
+++ b/addons/io_hubs_addon/components/definitions/networked.py
@@ -3,6 +3,7 @@ from bpy.props import StringProperty
 from ..types import PanelType, NodeType
 import uuid
 from ..utils import add_component
+from ...io.utils import import_component, assign_property
 import bpy
 
 
@@ -14,6 +15,17 @@ class Networked(HubsComponent):
         'panel_type': [PanelType.OBJECT, PanelType.BONE],
         'version': (1, 0, 0)
     }
+
+    @classmethod
+    def gather_import(cls, gltf, blender_host, component_name, component_value, import_report, blender_ob=None):
+        blender_component = import_component(component_name, blender_host)
+        if component_value:
+            for property_name, property_value in component_value.items():
+                if property_name != "id":
+                    # ids are generated at export time, so they shouldn't be imported.
+                    assign_property(gltf.vnodes,
+                                    blender_host, blender_component,
+                                    property_name, property_value, import_report)
 
     def gather(self, export_settings, object):
         return {

--- a/addons/io_hubs_addon/components/definitions/particle_emitter.py
+++ b/addons/io_hubs_addon/components/definitions/particle_emitter.py
@@ -188,5 +188,6 @@ class ParticleEmitter(HubsComponent):
             if property_name in ['startVelocity', 'endVelocity'] and gltf_yup:
                 property_value['y'], property_value['z'] = property_value['z'], property_value['y']
 
-            assign_property(gltf.vnodes, blender_component,
-                            property_name, property_value)
+            assign_property(gltf.vnodes,
+                            blender_host, blender_component,
+                            property_name, property_value, import_report)

--- a/addons/io_hubs_addon/components/definitions/reflection_probe.py
+++ b/addons/io_hubs_addon/components/definitions/reflection_probe.py
@@ -776,8 +776,9 @@ class ReflectionProbe(HubsComponent):
         # Import the component
         component = import_component(component_name, lightprobe_object)
         lightprobe_data.influence_distance = component_value["size"]
-        assign_property(gltf.vnodes, component,
-                        "envMapTexture", component_value["envMapTexture"])
+        assign_property(gltf.vnodes,
+                        blender_host, component,
+                        "envMapTexture", component_value["envMapTexture"], import_report)
 
     @classmethod
     def draw_global(cls, context, layout, panel):

--- a/addons/io_hubs_addon/components/definitions/spawner.py
+++ b/addons/io_hubs_addon/components/definitions/spawner.py
@@ -53,5 +53,6 @@ class Spawner(HubsComponent):
                 setattr(blender_component, "applyGravity",
                         property_value["applyGravity"])
             else:
-                assign_property(gltf.vnodes, blender_component,
-                                property_name, property_value)
+                assign_property(gltf.vnodes,
+                                blender_host, blender_component,
+                                property_name, property_value, import_report)

--- a/addons/io_hubs_addon/components/definitions/spoke/box_collider.py
+++ b/addons/io_hubs_addon/components/definitions/spoke/box_collider.py
@@ -12,10 +12,12 @@ class BoxCollider(HubsComponent):
     @classmethod
     def gather_import(cls, gltf, blender_host, component_name, component_value, import_report, blender_ob=None):
         blender_component = import_component('ammo-shape', blender_host)
-        assign_property(gltf.vnodes, blender_component,
-                        "type", 'box')
-        assign_property(gltf.vnodes, blender_component,
-                        "fit", 'manual')
+        assign_property(gltf.vnodes,
+                        blender_host, blender_component,
+                        "type", 'box', import_report)
+        assign_property(gltf.vnodes,
+                        blender_host, blender_component,
+                        "fit", 'manual', import_report)
 
         # These settings don't get applied when set as normal here, so use a timer to set them later.
         def set_half_extents_and_offsets():

--- a/addons/io_hubs_addon/components/definitions/spoke/spawn_point.py
+++ b/addons/io_hubs_addon/components/definitions/spoke/spawn_point.py
@@ -12,5 +12,6 @@ class SpawnPoint(HubsComponent):
     @classmethod
     def gather_import(cls, gltf, blender_host, component_name, component_value, import_report, blender_ob=None):
         blender_component = import_component('waypoint', blender_host)
-        assign_property(gltf.vnodes, blender_component,
-                        "canBeSpawnPoint", True)
+        assign_property(gltf.vnodes,
+                        blender_host, blender_component,
+                        "canBeSpawnPoint", True, import_report)

--- a/addons/io_hubs_addon/components/definitions/text.py
+++ b/addons/io_hubs_addon/components/definitions/text.py
@@ -238,5 +238,6 @@ class Text(HubsComponent):
                 if type(property_value) is int or type(property_value) is float:
                     property_value = str(property_value)
 
-            assign_property(gltf.vnodes, blender_component,
-                            property_name, property_value)
+            assign_property(gltf.vnodes,
+                            blender_host, blender_component,
+                            property_name, property_value, import_report)

--- a/addons/io_hubs_addon/components/hubs_component.py
+++ b/addons/io_hubs_addon/components/hubs_component.py
@@ -126,8 +126,10 @@ class HubsComponent(PropertyGroup):
         component = import_component(component_name, blender_host)
         if component_value:
             for property_name, property_value in component_value.items():
-                assign_property(gltf.vnodes, component,
-                                property_name, property_value)
+                assign_property(gltf.vnodes,
+                                blender_host, component,
+                                property_name, property_value,
+                                import_report, blender_ob=blender_ob)
 
     def post_export(self, export_settings, host, ob=None):
         '''This is called by the exporter after the export process has finished'''

--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -517,7 +517,18 @@ def set_color_from_hex(blender_component, property_name, hexcolor):
         getattr(blender_component, property_name)[x] = rgb_float
 
 
-def assign_property(vnodes, blender_component, property_name, property_value):
+def assign_property(
+        vnodes, blender_host, blender_component, property_name, property_value, import_report, blender_ob=None):
+    if not hasattr(blender_component, property_name):
+        from ..components.utils import get_host_reference_message  # imported here to prevent a circular import
+        blender_component_name = blender_component.get_name()
+        panel_type = get_panel_type_from_host(blender_host)
+        host_reference = get_host_reference_message(panel_type, blender_host, ob=blender_ob)
+        warning = f"Warning: Could not assign property \"{property_name}\" to component \"{blender_component_name}\" on the {panel_type.value} {host_reference}"
+        import_report.append(warning)
+        print(warning)
+        return
+
     if isinstance(property_value, dict):
         if property_value.get('__mhc_link_type'):
             if len(property_value) == 2:
@@ -548,6 +559,16 @@ def assign_property(vnodes, blender_component, property_name, property_value):
         set_color_from_hex(blender_component, property_name, property_value)
 
     else:
-        if not hasattr(blender_component, property_name):
-            return
         setattr(blender_component, property_name, property_value)
+
+
+def get_panel_type_from_host(host):
+    from ..components.types import PanelType  # imported here to prevent a circular import
+    if type(host) in [bpy.types.Bone, bpy.types.EditBone, bpy.types.PoseBone]:
+        return PanelType.BONE
+    elif type(host) is bpy.types.Scene:
+        return PanelType.SCENE
+    elif type(host) is bpy.types.Material:
+        return PanelType.MATERIAL
+    else:
+        return PanelType.OBJECT


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Updates the assign_property function to assemble a warning message, detailing what property was attempted to be assigned where, if the property is unrecognized and can't be assigned, and displays this to the user via both the import report and terminal prints.

Moves the check for whether the property is recognized to the beginning of the assign_property function.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Properties could fail to import and be silently skipped, thus resulting in an only partially successful import without the user knowing.

Moving the check prevents any unrecognized properties from being assigned, even if they can otherwise be understood, e.g. if they have a value that is a special type like an object or color.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
Before when importing "CASE_2020_-_ATRIO_by_Hubs_Team_id_Y8y8GpW.glb" from the hubs-blender-files repository there were no warnings, now there are these:
<img width="827" height="537" alt="2026-08-19_08-25" src="https://github.com/user-attachments/assets/dd8f50e3-d850-4f72-ac0d-0910e602ddee" />


## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Import `CASE_2020_-_ATRIO_by_Hubs_Team_id_Y8y8GpW.glb` from the hubs-blender-files repository (in `demo-server > hubs_scenes_export`) without the changes from this pull request.
2. See there are no errors.
3. Select the gatheringHall-unbranded_01_rotatingSign-worldCentered.glb object and see that it's Loop Animation component doesn't have any tracks (i.e. it didn't import correctly).
4. Repeat the process with the changes from this pull request and see that you are warned that the Loop Animation component didn't import correctly.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
The report viewer and its warnings aren't currently documented anywhere, so there isn't any documentation to update at present, and the warnings aren't significantly changed, there are just more now so you can better know if something has gone wrong.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
Passing the errors back from the assign_property function to the gather_import functions so that the import report could be shown without needing to pass it into assign_property was considered, but this ended up being much more complex and not as robust as passing the import report into assign_property and filling it out there.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
The networked component was updated to explicitly discard the id property so that the user isn't erroneously warned (ids are generated at export, so they shouldn't be imported).  It also loops through all the properties, even though currently there is only the id property, so that if any further properties are added in the future they will be imported automatically as usual.

Part of "Fix branding removal related GLB import/export issues in the Hubs Blender add-on" on the [Programming Team's roadmap](https://docs.google.com/document/d/1xRSHEgf4jE4SRsx2Z5BX_uXKbJ7KuCW3v0ntugA76io/edit?tab=t.0).