### PR TITLE
Add support for importing Spoke Loop Animation components

### DIFF
--- a/addons/io_hubs_addon/components/definitions/loop_animation.py
+++ b/addons/io_hubs_addon/components/definitions/loop_animation.py
@@ -953,6 +953,15 @@ class LoopAnimation(HubsComponent):
             if property_name == 'clip' and property_value != "":
                 tracks = property_value.split(",")
                 import_tracks(tracks, blender_ob, blender_component)
+            elif property_name == 'activeClipIndex':
+                # Importing from Spoke
+                tracks = [gltf.data.animations[property_value].name]
+                import_tracks(tracks, blender_ob, blender_component)
+            elif property_name == 'activeClipIndices':
+                # Importing from Spoke
+                for index in property_value:
+                    tracks = [gltf.data.animations[index].name]
+                    import_tracks(tracks, blender_ob, blender_component)
             else:
                 if property_name == 'startOffset':
                     fps = bpy.context.scene.render.fps / bpy.context.scene.render.fps_base


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a check for properties named `activeClipIndex` and `activeClipIndices`; if either of these are found, the importer will look up the animation name(s) by index from the glTF file (instead of getting the names directly from the clip property, which isn't present) and attempt to assign the correct tracks to the component.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Spoke doesn't use the `clip` property and instead uses `activeClipIndices`, or `activeClipIndex` to reference which animation tracks should be looping.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Unzip and import the GLB from [Crater_2026-08-19.zip](https://github.com/user-attachments/files/31223543/Crater_2026-08-19.zip).
2. See that the Loop Animation components on the fan thing and wolf have been filled out with tracks.
3. Import `CASE_2020_-_ATRIO_by_Hubs_Team_id_Y8y8GpW.glb` from the hubs-blender-files repository (in `demo-server > hubs_scenes_export`).
4. Select the gatheringHall-unbranded_01_rotatingSign-worldCentered.glb object and see that it's Loop Animation component has a track.

Note: without the changes from this PR the Loop Animation components should be present, but won't have any tracks.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
Which variations of Loop Animation components are supported isn't documented anywhere (theoretically they all should be supported), so no documentation needs to be updated.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
`activeClipIndex` appears to be from a time before multiple tracks were supported and doesn't appear to be used in the current Spoke (so it's likely only present in GLB files that were exported from older versions of Spoke).

Part of "Fix branding removal related GLB import/export issues in the Hubs Blender add-on" on the [Programming Team's roadmap](https://docs.google.com/document/d/1xRSHEgf4jE4SRsx2Z5BX_uXKbJ7KuCW3v0ntugA76io/edit?tab=t.0).