### PR TITLE
Fix offset armature animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ This addon works in conjunction with the official glTF add-on, so exporting is d
 
 ![gltf export window](https://user-images.githubusercontent.com/130735/84547591-be9ad700-acb8-11ea-8c58-7b1104f0a3a7.png)
 
+## Options
+
+- Fix Offset Armature Animation
+  - Fixes the animation for non-centered armature animation driven objects by unparenting the objects before export (objects are automatically reparented afterward)
+
 # Import into Hubs
 
 The easiest way to use your scene file is through the Spoke project creation page and selecting _Import From Blender_:

--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -23,6 +23,7 @@ def patched_gather_gltf(exporter, export_settings):
 
 EXTENSION_NAME = HUBS_CONFIG["gltfExtensionName"]
 EXTENSION_VERSION = HUBS_CONFIG["gltfExtensionVersion"]
+OFFSET_ARMATURE_OBJECTS = {}
 
 
 def get_version_string():
@@ -37,6 +38,7 @@ def export_callback(callback_method, export_settings):
     # because a name change will cause Blender to update the host lists in
     # mid iteration and so multiple callbacks could be executed for the same
     # component/host.
+    hubs_export_props = bpy.context.scene.HubsComponentsExtensionProperties
 
     for scene in bpy.data.scenes[:]:
         for component in get_host_components(scene):
@@ -55,6 +57,8 @@ def export_callback(callback_method, export_settings):
                 traceback.print_exc()
 
         if ob.type == 'ARMATURE':
+            if hubs_export_props.fix_offset_armature_animation:
+                fix_offset_armature_animation(callback_method, ob)
             for bone in ob.data.bones[:]:
                 for component in get_host_components(bone):
                     component_callback = getattr(component, callback_method)
@@ -81,6 +85,7 @@ def glTF2_pre_export_callback(export_settings):
         from io_scene_gltf2.blender.com.gltf2_blender_extras import BLACK_LIST
 
     BLACK_LIST.extend(glTF2ExportUserExtension.EXCLUDED_PROPERTIES)
+    OFFSET_ARMATURE_OBJECTS.clear()
     export_callback("pre_export", export_settings)
 
 
@@ -93,9 +98,34 @@ def glTF2_post_export_callback(export_settings):
         from io_scene_gltf2.blender.com.gltf2_blender_extras import BLACK_LIST
 
     export_callback("post_export", export_settings)
+    OFFSET_ARMATURE_OBJECTS.clear()
     for excluded_prop in glTF2ExportUserExtension.EXCLUDED_PROPERTIES:
         if excluded_prop in BLACK_LIST:
             BLACK_LIST.remove(excluded_prop)
+
+
+def fix_offset_armature_animation(callback_method, armature_ob):
+    if not any(armature_ob.matrix_world.to_translation()):
+        return
+
+    if callback_method == "pre_export":
+        for child_ob in armature_ob.children:
+            # unparent the child object but keep its transformation
+            orig_matrix_world = child_ob.matrix_world.copy()
+            child_ob.parent = None
+            child_ob.matrix_world = orig_matrix_world
+
+            # store the child object for reparenting after the export is finished
+            if armature_ob not in OFFSET_ARMATURE_OBJECTS:
+                OFFSET_ARMATURE_OBJECTS[armature_ob] = []
+            OFFSET_ARMATURE_OBJECTS[armature_ob].append(child_ob)
+
+    else:
+        for child_ob in OFFSET_ARMATURE_OBJECTS[armature_ob]:
+            # reparent the child object and keep its transformation
+            orig_matrix_world = child_ob.matrix_world.copy()
+            child_ob.parent = armature_ob
+            child_ob.matrix_world = orig_matrix_world
 
 
 # This class name is specifically looked for by gltf-blender-io and it's hooks are automatically invoked on export
@@ -245,6 +275,10 @@ class HubsComponentsExtensionProperties(bpy.types.PropertyGroup):
         description='Include this extension in the exported glTF file',
         default=True
     )
+    fix_offset_armature_animation: bpy.props.BoolProperty(
+        name="Fix Offset Armature Animation",
+        description='Fixes the animation for non-centered armature animation driven objects by unparenting the objects before export (objects are automatically reparented afterward)',
+        default=True)
 
 
 class HubsGLTFExportPanel(bpy.types.Panel):
@@ -279,7 +313,7 @@ class HubsGLTFExportPanel(bpy.types.Panel):
         layout.active = props.enabled
 
         box = layout.box()
-        box.label(text="No options yet")
+        box.prop(props, "fix_offset_armature_animation")
 
 
 def register():


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a preference to the export panel that, if enabled, causes the pre_export hook to check whether any armatures aren't in the center of the scene, and if so, unparents all their children (keeping their transforms), then in the post_export hook, the children are restored to their parents (keeping their transforms) so that everything is returned to as it was before the export.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
The origin of the objects doesn't seem to get exported correctly (it's offset an additional amount) when the objects are parented to an armature and the objects/armature aren't in the center of the scene.  This causes issues with Hubs frustum culling (because it's based on the object origins) and results in the objects being culled when they shouldn't be.  Unparenting the objects appears to be the only way to fix this (and is possibly the recommended way to export armature animated objects[1][2], though the glTF exporter complains, so not sure).  The preference was added because this does significantly modify the scene during export and this may not always be wanted.

[1] https://github.com/KhronosGroup/glTF-Blender-IO/issues/1626
[2] https://github.com/KhronosGroup/glTF-Blender-IO/issues/1970

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
Without the PR:
<img width="1920" height="856" alt="2026-08-19_09-23" src="https://github.com/user-attachments/assets/c90acf44-cfa6-44aa-94f5-ec082fdc70fa" />

With the PR:
<img width="1919" height="855" alt="2026-08-19_09-25" src="https://github.com/user-attachments/assets/948b8a9f-d72d-40f3-a58d-c75bc78e7b22" />


## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Extract the blend file and then export a GLB with this PR from [offset_armatures_test_export.zip](https://github.com/user-attachments/files/31224686/offset_armatures_test_export.zip).
2. Drop the GLB in a room you own with the debugLocalScene query string added.
3. See that everything shows up properly.
4. Then export a GLB from the same file, but without this PR.
5. Drop the GLB in a room you own with the debugLocalScene query string added.
6. See that the rotating signs are gone and occasionally pop into existence depending on view angle.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
Documentation for the new export option has been added to the readme file.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
Is changing the GLB export the correct way to fix the culling issue with non-centered armature animations or is a better fix to fix something in the Hubs client?  Given that the Hubs client doesn't have any issues with the GLBs provided by Spoke with non-centered armature animations and the discussions on the glTF repository, I'm inclined to think that this is the correct way to fix the issue, but at the very least I don't think it does any harm and it reduces the warnings from glTF validation reports.  Thoughts?

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
While this does change the exported glTF file, upon re-import the glTF add-on restores the parent-child relationship, so round tripping is unaffected.

The fixes from https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/353 are needed to be able to view/interact with the export option in Blender versions 4.4+.

Part of "Fix branding removal related GLB import/export issues in the Hubs Blender add-on" on the [Programming Team's roadmap](https://docs.google.com/document/d/1xRSHEgf4jE4SRsx2Z5BX_uXKbJ7KuCW3v0ntugA76io/edit?tab=t.0).