### PR TITLE
Fix export of names from imported HDR images

### DIFF
--- a/addons/io_hubs_addon/io/utils.py
+++ b/addons/io_hubs_addon/io/utils.py
@@ -141,6 +141,10 @@ def gather_image(blender_image, export_settings):
     name, _extension = os.path.splitext(
         os.path.basename(blender_image.filepath))
 
+    if not name:
+        # No filepath was set, so fall back to using the image datablock's name.  This likely means we are dealing with an image that was imported from a glTF file.
+        name = blender_image.name
+
     if export_settings["gltf_image_format"] == "AUTO":
         if blender_image.file_format == "HDR":
             mime_type = "image/vnd.radiance"


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Changes the gather_image function to fall back to using the image datablock's name for the exported image name if the datablock's filepath property isn't set.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
Images imported from glTF files don't get their filepath property set, so when we export HDR images the name would end up being blank (we get the name from the filepath).  Falling back to using the image datablock's name hopefully ensures that at least some name is exported (and it will likely be the correct one, at least when dealing with imported images, since glTF passes the image name to the datablock when importing).

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Extract the GLB from this zip and import it into Blender: [re-export_hdr_image_name_test.zip](https://github.com/user-attachments/files/31225595/re-export_hdr_image_name_test.zip).
2. Export what you imported to an empty folder using the glTF Separate format (not a binary GLB).
3. Check the HDR image and see that it has a name
4. Repeat the above steps without the PR and see that the HDR image doesn't have a name.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
Bug fix of an undocumented implementation detail.  No documentation update required.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
Always using the image datablock's name for export, but using the filepath is preferred since it can be more descriptive than the image datablock's name (e.g. the datablock name can often be something like "Untitled" since the datablock name isn't updated when its image is saved), so the filepath is kept as the primary source of the name.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
Part of "Fix branding removal related GLB import/export issues in the Hubs Blender add-on" on the [Programming Team's roadmap](https://docs.google.com/document/d/1xRSHEgf4jE4SRsx2Z5BX_uXKbJ7KuCW3v0ntugA76io/edit?tab=t.0).