### PR TITLE
Remove material export workaround for Blender 5.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["3.6.23", "4.0.2", "4.1.1", "4.2.22", "4.3.2", "4.4.3", "4.5.11", "5.0.1", "5.1.2", "5.2.0"]
+        version: ["3.6.23", "4.0.2", "4.1.1", "4.2.22", "4.3.2", "4.4.3", "4.5.11", "5.0.1", "5.1.2", "5.2.1"]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/addons/io_hubs_addon/io/gltf_exporter.py
+++ b/addons/io_hubs_addon/io/gltf_exporter.py
@@ -165,10 +165,6 @@ class glTF2ExportUserExtension:
         if not self.properties.enabled:
             return
 
-        if bpy.app.version >= (5, 2, 0):
-            # The glTF add-on in Blender 5.2+ no longer passes the actual Blender material, so we need to look it up ourselves
-            blender_material = bpy.data.materials[gltf2_object.name]
-
         self.export_hubs_components(
             gltf2_object, blender_material, export_settings)
 
@@ -184,10 +180,6 @@ class glTF2ExportUserExtension:
                 )
 
     def gather_material_unlit_hook(self, gltf2_object, blender_material, export_settings):
-        if bpy.app.version >= (5, 2, 0):
-            # The glTF add-on in Blender 5.2+ no longer passes the actual Blender material, so we need to look it up ourselves
-            blender_material = bpy.data.materials[gltf2_object.name]
-
         self.gather_material_hook(
             gltf2_object, blender_material, export_settings)
 


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Removes the workaround for material export that was added for Blender 5.2.0 and updates the publish workflow to use Blender 5.2.1.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
The issue has been fixed on the glTF side and (is planned to be) backported to Blender 5.2.1

glTF issue/PR links:
https://github.com/KhronosGroup/glTF-Blender-IO/issues/2732 https://github.com/KhronosGroup/glTF-Blender-IO/pull/2733

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
N/A

## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Open Blender 5.2.1 from a terminal
2. Export a scene with a set of connected video texture source and video texture target components in it.
3. See that there are no errors reported in the terminal.
4. Load the exported GLB into Hubs and see that the video texture source/target works as expected.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
No functionality was changed, so no documentation update is needed.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
Blender 5.2.0 won't export materials correctly, but we expect that everyone should be running the latest corrective release for each main Blender version.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
Modifying the check so that it only targets Blender 5.2.0, but we haven't supported individual corrective releases before and supporting individual corrective releases would add a significant maintenance burden.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
Followup to PR https://github.com/Hubs-Foundation/hubs-blender-exporter/pull/355
This is put up as a draft release while waiting for Blender 5.2.1 to be released.
Blender 5.2 LTS Maintenance task: https://projects.blender.org/blender/blender/issues/161229
glTF commit to be backported: [blender/blender@e8ee27e2b1](https://projects.blender.org/blender/blender/commit/e8ee27e2b17bdfbf0866f6680a1c1081e7b4a275)